### PR TITLE
Initial design and layout using material UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
+    "@material-ui/core": "^4.11.0",
+    "@material-ui/icons": "^4.9.1",
     "@types/chrome": "0.0.117",
     "@types/react-html-parser": "^2.0.1",
     "@types/react-json-tree": "^0.6.11",

--- a/src/app/GraphiQL.tsx
+++ b/src/app/GraphiQL.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+function GraphiQL() {
+  return (
+    <div>
+      <p>This is the GraphiQL tab</p>
+    </div>
+  );
+}
+export default GraphiQL;

--- a/src/app/MainDrawer.tsx
+++ b/src/app/MainDrawer.tsx
@@ -1,0 +1,204 @@
+import React, {useState, useEffect} from 'react';
+
+import clsx from 'clsx';
+import {
+  createStyles,
+  makeStyles,
+  useTheme,
+  Theme,
+} from '@material-ui/core/styles';
+import Drawer from '@material-ui/core/Drawer';
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+import List from '@material-ui/core/List';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import Typography from '@material-ui/core/Typography';
+import Divider from '@material-ui/core/Divider';
+import IconButton from '@material-ui/core/IconButton';
+import MenuIcon from '@material-ui/icons/Menu';
+import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
+import ChevronRightIcon from '@material-ui/icons/ChevronRight';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import InboxIcon from '@material-ui/icons/MoveToInbox';
+import MailIcon from '@material-ui/icons/Mail';
+
+import GraphiQL from './GraphiQL';
+import Mutations from './Mutations';
+import Queries from './Queries';
+import Store from './Store';
+import Performance from './Performance';
+
+const drawerWidth = 240;
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+    },
+    appBar: {
+      zIndex: theme.zIndex.drawer + 1,
+      transition: theme.transitions.create(['width', 'margin'], {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.leavingScreen,
+      }),
+    },
+    appBarShift: {
+      marginLeft: drawerWidth,
+      width: `calc(100% - ${drawerWidth}px)`,
+      transition: theme.transitions.create(['width', 'margin'], {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.enteringScreen,
+      }),
+    },
+    menuButton: {
+      marginRight: 36,
+    },
+    hide: {
+      display: 'none',
+    },
+    drawer: {
+      width: drawerWidth,
+      flexShrink: 0,
+      whiteSpace: 'nowrap',
+    },
+    drawerOpen: {
+      width: drawerWidth,
+      transition: theme.transitions.create('width', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.enteringScreen,
+      }),
+    },
+    drawerClose: {
+      transition: theme.transitions.create('width', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.leavingScreen,
+      }),
+      overflowX: 'hidden',
+      width: theme.spacing(7) + 1,
+      [theme.breakpoints.up('sm')]: {
+        width: theme.spacing(9) + 1,
+      },
+    },
+    toolbar: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'flex-end',
+      padding: theme.spacing(0, 1),
+      // necessary for content to be below app bar
+      ...theme.mixins.toolbar,
+    },
+    content: {
+      flexGrow: 1,
+      padding: theme.spacing(3),
+    },
+  }),
+);
+
+export default function MainDrawer() {
+  const classes = useStyles();
+  const theme = useTheme();
+  const [open, setOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState('GraphiQL');
+
+  const handleDrawerOpen = () => {
+    setOpen(true);
+  };
+
+  const handleDrawerClose = () => {
+    setOpen(false);
+  };
+
+  let visibleTab;
+
+  useEffect(() => {
+    switch (activeTab) {
+      case 'GraphiQL':
+        visibleTab = <GraphiQL />;
+
+      case 'Mutations':
+        visibleTab = <Mutations />;
+
+      case 'Performance':
+        visibleTab = <Performance />;
+
+      case 'Queries':
+        visibleTab = <Queries />;
+
+      default:
+        visibleTab = <GraphiQL />;
+    }
+  }, [activeTab]);
+
+  return (
+    <div className={classes.root}>
+      <CssBaseline />
+      <AppBar
+        position="fixed"
+        className={clsx(classes.appBar, {
+          [classes.appBarShift]: open,
+        })}>
+        <Toolbar>
+          <IconButton
+            color="inherit"
+            aria-label="open drawer"
+            onClick={handleDrawerOpen}
+            edge="start"
+            className={clsx(classes.menuButton, {
+              [classes.hide]: open,
+            })}>
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" noWrap>
+            Apollo 11 Dev Tools
+          </Typography>
+        </Toolbar>
+      </AppBar>
+      <Drawer
+        variant="permanent"
+        className={clsx(classes.drawer, {
+          [classes.drawerOpen]: open,
+          [classes.drawerClose]: !open,
+        })}
+        classes={{
+          paper: clsx({
+            [classes.drawerOpen]: open,
+            [classes.drawerClose]: !open,
+          }),
+        }}>
+        <div className={classes.toolbar}>
+          <IconButton onClick={handleDrawerClose}>
+            {theme.direction === 'rtl' ? (
+              <ChevronRightIcon />
+            ) : (
+              <ChevronLeftIcon />
+            )}
+          </IconButton>
+        </div>
+        <Divider />
+        <List>
+          {['GraphiQL', 'Queries', 'Mutations', 'Store', 'Performance'].map(
+            (text, index) => (
+              <ListItem button key={text}>
+                <ListItemIcon
+                  onClick={() => console.log(`Button clicked===${text}`)}>
+                  {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+                </ListItemIcon>
+                <ListItemText
+                  primary={text}
+                  onClick={() => console.log(`Button clicked===${text}`)}
+                />
+              </ListItem>
+            ),
+          )}
+        </List>
+      </Drawer>
+      <main className={classes.content}>
+        <div className={classes.toolbar} />
+        <Typography paragraph>Loading App....Please wait....</Typography>
+        {visibleTab}
+      </main>
+    </div>
+  );
+}

--- a/src/app/MainDrawer.tsx
+++ b/src/app/MainDrawer.tsx
@@ -110,9 +110,10 @@ export default function MainDrawer() {
     setOpen(false);
   };
 
-  let visibleTab;
+  let visibleTab = <GraphiQL />;
 
   useEffect(() => {
+    console.log(`activeTab === ${activeTab}`);
     switch (activeTab) {
       case 'GraphiQL':
         visibleTab = <GraphiQL />;
@@ -180,15 +181,18 @@ export default function MainDrawer() {
         <List>
           {['GraphiQL', 'Queries', 'Mutations', 'Store', 'Performance'].map(
             (text, index) => (
-              <ListItem button key={text}>
-                <ListItemIcon
-                  onClick={() => console.log(`Button clicked===${text}`)}>
+              <ListItem
+                button
+                key={text}
+                onClick={() => {
+                  setActiveTab(`${text}`);
+                  console.log(`text === ${text}`);
+                  alert(`${text} was clicked`);
+                }}>
+                <ListItemIcon>
                   {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
                 </ListItemIcon>
-                <ListItemText
-                  primary={text}
-                  onClick={() => console.log(`Button clicked===${text}`)}
-                />
+                <ListItemText primary={text} />
               </ListItem>
             ),
           )}

--- a/src/app/Mutations.tsx
+++ b/src/app/Mutations.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+function Mutations() {
+  return (
+    <div>
+      <p>This is the Mutations tab</p>
+    </div>
+  );
+}
+export default Mutations;

--- a/src/app/Performance.tsx
+++ b/src/app/Performance.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+function Performance() {
+  return (
+    <div>
+      <p>This is the performance tab</p>
+    </div>
+  );
+}
+export default Performance;

--- a/src/app/Queries.tsx
+++ b/src/app/Queries.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+function Queries() {
+  return (
+    <div>
+      <p>This is the Queries tab</p>
+    </div>
+  );
+}
+export default Queries;

--- a/src/app/Store.tsx
+++ b/src/app/Store.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+function Store() {
+  return (
+    <div>
+      <p>This is the Store tab</p>
+    </div>
+  );
+}
+export default Store;

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
+import MainDrawer from './MainDrawer';
 
 function App() {
-  return <div>Hello from App</div>;
+  return (
+    <div>
+      <MainDrawer />
+    </div>
+  );
 }
 export default App;

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './app.tsx';
+import App from './App';
 
 ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
Feature: Initial design and layout using material UI

Description:
Initial design created with Matt. We selected material UI and added the sidebar and general layout of the extension. 

Changes I Made:
- Material UI added to project
- Mini Variant Drawer added to project
- Menu items added with text to match features
- Components added for each feature as .tsx files
- Menu items will alert on click of the menu item clicked 
- NOTE: Menu items currently not rendering components in main section on click

How to Test:
- Install dependencies with "npm install"
- Run "npm run build" to build the project for the chrome extension
- Go to Chrome browser > Extensions
- Toggle "Developer Mode" switch to be on
- Click the "Load Unpacked" button
- Select the "Build" folder from the project directory 
- Navigate to a new tab in the browser
- From the menu, select "Tools" > "Developer Tools"
- In the developer tools section, click "Apollo11" to test the changes
