### PR TITLE
Add pre-commit git hook support

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.5",
     "eslint-plugin-react-hooks": "^4.0.8",
+    "ghooks": "^2.0.4",
     "jest": "^26.1.0",
     "prettier": "^2.0.5",
     "ts-loader": "^7.0.5",
@@ -65,5 +66,10 @@
   },
   "engines": {
     "node": "^10.12.0 || >=12.0.0"
+  },
+  "config": {
+    "ghooks": {
+      "pre-commit": "npm run lint"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "webpack --mode development --watch",
     "verify:test": "jest --verbose",
     "verify:lint": "eslint '**/*.tsx' '**/*.ts' '**/*.js' --ignore-path .gitignore",
-    "validate": "npm-run-all --parallel verify:*"
+    "precommit": "npm-run-all --parallel verify:lint"
   },
   "author": "matt rob lanre steve",
   "license": "MIT",
@@ -40,6 +40,7 @@
     "eslint-plugin-react-hooks": "^4.0.8",
     "ghooks": "^2.0.4",
     "jest": "^26.1.0",
+    "json-loader": "^0.5.7",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
     "ts-loader": "^7.0.5",
@@ -71,7 +72,7 @@
   },
   "config": {
     "ghooks": {
-      "pre-commit": "npm run validate"
+      "pre-commit": "npm run precommit"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-plugin-react-hooks": "^4.0.8",
     "ghooks": "^2.0.4",
     "jest": "^26.1.0",
-    "json-loader": "^0.5.7",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
     "ts-loader": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "build": "webpack --mode production",
     "dev": "webpack --mode development --watch",
-    "test": "jest --verbose",
-    "lint": "eslint '**/*.tsx' '**/*.ts' '**/*.js' --ignore-path .gitignore"
+    "verify:test": "jest --verbose",
+    "verify:lint": "eslint '**/*.tsx' '**/*.ts' '**/*.js' --ignore-path .gitignore",
+    "validate": "npm-run-all --parallel verify:*"
   },
   "author": "matt rob lanre steve",
   "license": "MIT",
@@ -39,6 +40,7 @@
     "eslint-plugin-react-hooks": "^4.0.8",
     "ghooks": "^2.0.4",
     "jest": "^26.1.0",
+    "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
     "ts-loader": "^7.0.5",
     "typescript": "^3.9.6",
@@ -69,7 +71,7 @@
   },
   "config": {
     "ghooks": {
-      "pre-commit": "npm run lint"
+      "pre-commit": "npm run validate"
     }
   }
 }


### PR DESCRIPTION
**Feature**:
Pre-Commit Git Hook

**Description**:
This will allow us to add a pre-commit hook.  This hook will run the `npm run lint` script on any git commit command.  If there are errors returned from the linter, it will block the commit from executing.  In addition, we can also enable this for any tests as well.

**Changes I Made**:
Added two packages:  `npm-run-all` and `ghooks`.  The `npm-run-all` package will allow us to run multiple scripts.  The `ghooks` package implements the git hooks functionality.

`package.json`
- Modified the `scripts` section in such that it adds a `verify:` prefix to the `test` and `lint` script commands.  In the future, we can then use `npm-run-all` to run all `verify:*` scripts.  Currently, we will only be running the linter as we don't have any tests yet.
- Added a `config` section to configure the `pre-commit` git hook.

**Installation**:
Run `npm install` to add the new packages.

**How to Test**:
Run `npm run precommit` to manually execute the git hook, or commit some files locally and execute a `git commit` which will trigger the `pre-commit` git hook automatically.
