### PR TITLE
Apollo detection

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
     browser: true,
     es2020: true,
     webextensions: true,
+    node: true,
   },
   extends: [
     'airbnb',
@@ -22,7 +23,7 @@ module.exports = {
   },
   plugins: ['flowtype', 'react', 'jsx-a11y', 'prettier'],
   rules: {
-    'prettier/prettier': ['error'],
+    'prettier/prettier': ['warn'],
     'react/prop-types': 'off',
     'react/jsx-filename-extension': [
       1,
@@ -30,6 +31,7 @@ module.exports = {
         extensions: ['.js', '.jsx'],
       },
     ],
+    'no-underscore-dangle': 'off',
   },
   settings: {
     react: {

--- a/src/extension/contentScript.ts
+++ b/src/extension/contentScript.ts
@@ -1,1 +1,50 @@
-console.log('this is contentScript.ts');
+console.log('Executing contentScript.ts...');
+
+interface IApolloClientHook {
+  Apollo11Client: any;
+}
+
+function detectApolloClient(window: any) {
+  const apolloClientHook: IApolloClientHook = {
+    Apollo11Client: null,
+  };
+
+  if (window.__APOLLO_DEVTOOLS_GLOBAL_HOOK__ === 'undefined') {
+    Object.defineProperty(window, '__APOLLO_DEVTOOLS_GLOBAL_HOOK__', {
+      get() {
+        return apolloClientHook;
+      },
+    });
+  } else {
+    Object.assign(window.__APOLLO_DEVTOOLS_GLOBAL_HOOK__, apolloClientHook);
+  }
+
+  // Need to add this eslint global to mitigate the following error:
+  //   22:26  error    'NodeJS' is not defined       no-undef
+  /* global NodeJS */
+  let detectionInterval: NodeJS.Timeout;
+
+  function findApolloClient() {
+    if (window.__APOLLO_CLIENT__) {
+      apolloClientHook.Apollo11Client = window.__APOLLO_CLIENT__;
+      clearInterval(detectionInterval);
+      console.log('findClient - found Apollo client: ', apolloClientHook.Apollo11Client);
+    }
+  }
+
+  // TODO: We are only clearing the timer if the Apollo client is found, otherwise it will
+  // keep running indefinitely.  We should consider stopping it after some extended period
+  // of time, such as 10 minutes?  The original Apollo client code stopped after 10 seconds.
+  detectionInterval = setInterval(findApolloClient, 1000);
+}
+
+// Need to inject our script as an IIFE into the DOM
+// This will allow us to obtain the __APOLLO_CLIENT__ object
+// on the application's window object.
+// https://stackoverflow.com/questions/12395722/can-the-window-object-be-modified-from-a-chrome-extension
+if (document instanceof HTMLDocument) {
+  const script = document.createElement('script');
+  script.textContent = `;(${detectApolloClient.toString()})(window)`;
+  document.documentElement.appendChild(script);
+  script.parentNode.removeChild(script);
+}


### PR DESCRIPTION
**Feature**:
Apollo Client Detection

**Description**:
This will attempt to detect the Apollo Client on any application.  It does this by injecting the content script into every web page and immediately running the detection logic.

**Changes I Made**:
- The detection logic is executed in an interval timer that runs every 1000ms.  The detection is based on the presence of a global `__APOLLO_CLIENT__` object on the `window` object.  Furthermore, it will add this object as a hook on the `window.__APOLLO_DEVTOOLS_GLOBAL_HOOK__` object so that the extension can access it later.
- Upon successful detection, it will clear the interval timer.  Otherwise, it will be running indefinitely.  We should consider stopping this after some extended time, such as 10 minutes.  The original Apollo Dev Tool extension stopped after 10 seconds.

- Additionally, the linting rules in `.eslintrc.js` were modified as follows:
prettier has been changed to `warn` instead of `error` as these are purely stylistic
`no-underscore-dangle` has been turned off because of the required `__APOLLO_CLIENT__` and `__APOLLO_DEVTOOLS_GLOBAL_HOOK__` labels

**How to Test**:
Install the extension and open a website that has an Apollo Client, such as:  http://controlmy.lighting
Once detected, you should see a console message that prints out the Apollo Client object.
