### PR TITLE
Listen for GraphQL network requests

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -10,13 +10,35 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
 const App = () => {
   const [requestURI, setRequestURI] = useState('');
+  const [queries, setQueries] = useState([]);
+  const [mutations, setMutations] = useState([]);
+
   useEffect(() => {
     chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       console.log('request received on GraphiQL tab:', request);
       setRequestURI(request.apolloURI);
       sendResponse('Hello from React');
     });
-  }, []);
+    chrome.devtools.network.onRequestFinished.addListener((httpReq: any) => {
+      if (
+        httpReq.request.url === requestURI &&
+        httpReq.request.method === 'POST'
+      ) {
+        console.log('GraphQL Request: ', httpReq);
+        const query = JSON.parse(httpReq.request.postData.text);
+        if (query.query.startsWith('query')) {
+          setQueries(prevQueries => [...prevQueries, query]);
+        } else if (query.query.startsWith('mutation')) {
+          setMutations(prevMutations => [...prevMutations, query]);
+        }
+      }
+    });
+  }, [requestURI]);
+
+  useEffect(() => {
+    console.log('Current Queries', queries);
+    console.log('Current Mutations: ', mutations);
+  }, [queries, mutations]);
 
   return (
     <div>


### PR DESCRIPTION
**Feature:**
Listen for GraphQL network requests

**Description:**
- Adds an event listener to the React app that will listen for any network events and filter them for GraphQL requests.  If any queries or mutations are seen, it will push them to their corresponding query or mutation arrays.
- Two new hooks were added to store the queries and mutations, but we can combine this if needed in one object.  Currently we're only storing some basic info about the queries, but will likely need to add more data to it, such as timing metrics.
- The useEffect has a dependency on [requestURI] because the first time the event listener is called, it might not have the GraphQL URI yet.  So once requestURI is updated with the detected GraphQL URI (from the contentScript), it will have updated the listener with the right one to listen on.

**How to test:**
Load the extension and generate some GraphQL queries or mutations from the client to some GraphQL server.  Inspect the `panel` script and check for these `console.log` entries:

```
GraphQL Request: [object]
Current Queries: [array]
Current Mutations: [array]
```

