### PR TITLE
Fix messaging logic between app and contentscript

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useEffect} from 'react';
 
 import MainDrawer from './MainDrawer';
-import createURICacheListener from './utils/messaging';
+import createURICacheListener, {getApolloClient} from './utils/messaging';
 import createNetworkListener from './utils/networking';
 
 const App = () => {
@@ -9,15 +9,20 @@ const App = () => {
   const [events, setEvents] = useState({});
 
   useEffect(() => {
-    // Event listener to obtain the GraphQL server endpoint (URI)
-    // and the cache from the Apollo Client
+    // Only create the listener when the App is initially mounted
+    // i.e., when the requestURI is empty
+    // Otherwise we will be creating multiple listeners
     if (requestURI === '') {
+      // Event listener to obtain the GraphQL server endpoint (URI)
+      // and the cache from the Apollo Client
       createURICacheListener(setRequestURI, setEvents);
+
+      // Initial load of the App, so send a message to the contentScript to get the cache
+      getApolloClient();
     } else {
+      // Listen for network events only when we have a valid Apollo Client URI
       createNetworkListener(requestURI, setEvents);
     }
-
-    // Listen for network events
   }, [requestURI]);
 
   useEffect(() => {

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -1,5 +1,9 @@
 import React from 'react';
 
+// Listen for messages from the contentScript
+// The contentScript will send to the App:
+// - Apollo Client URI
+// - Apollo Client cache
 export default function createURICacheListener(
   setRequestURI: React.Dispatch<React.SetStateAction<string>>,
   setEvents: React.Dispatch<React.SetStateAction<{}>>,
@@ -9,6 +13,11 @@ export default function createURICacheListener(
     setRequestURI(request.apolloURI);
     setEvents((evnts: any) => {
       const eventsTmp = evnts;
+
+      // Check if this is the initial message sent by the contentScript
+      // The initial message will not have a cacheId (i.e. null)
+      // All subsequent messages will have a cacheId, so save the cache in the Events object
+      // using the cacheId as the key
       if (request.cacheId !== 'null') {
         if (eventsTmp[request.cacheId]) {
           eventsTmp[request.cacheId].cache = request.apolloCache;
@@ -20,8 +29,7 @@ export default function createURICacheListener(
         // This is the very first message received without a pre-generated cacheId,
         // so set cacheId to zero so it is the smallest value key in the events object
         // This keeps the first cache sent to be chronologically the first one in the events object
-        const newCacheId = 0;
-        // eventsTmp[newCacheId] = {cache: request.apolloCache};
+        const newCacheId = '0';
         if (eventsTmp[newCacheId]) {
           eventsTmp[newCacheId].cache = request.apolloCache;
         } else {
@@ -30,5 +38,24 @@ export default function createURICacheListener(
       }
       return eventsTmp;
     });
+  });
+}
+
+// Send a message to the contentScript to get the Apollo Client cache
+// Need to pass it the pre-generated cacheId so it can correlate the cache + data
+// with its corresponding network request
+export function getApolloClient(cacheId: string = 'null') {
+  // console.log('getApolloClient called with cacheId', cacheId);
+  // Get the active tab and send a message to the contentScript to get the cache
+  chrome.tabs.query({active: true}, function getClientData(tabs) {
+    // console.log('getApolloClient executing tabs.query with tabs', tabs);
+    if (tabs.length) {
+      // console.log('getApolloClient sending message to get cache');
+      chrome.tabs.sendMessage(tabs[0].id, {
+        type: 'GET_CACHE',
+        cacheId,
+      });
+      // console.log('getApolloClient setting Event with operation, timing, etc');
+    }
   });
 }

--- a/src/app/utils/networking.ts
+++ b/src/app/utils/networking.ts
@@ -1,9 +1,14 @@
 import React from 'react';
 
+import {getApolloClient} from './messaging';
+
+// The response payload is not immediately available on the httpReq object
+// i.e., you can't simply get it using httpReq.response.content
+// Instead, you have to invoke the httpReq.getContent() method
 function getNetworkResponsePayload(
   httpReq: any,
   setEvents: React.Dispatch<React.SetStateAction<{}>>,
-  cacheId: number,
+  cacheId: string,
 ) {
   // console.log('getNetworkResponsePayload called with cacheId', cacheId);
   httpReq.getContent((content: string) => {
@@ -22,51 +27,16 @@ function getNetworkResponsePayload(
     });
   });
 }
-function getApolloClient(
-  cacheId: number,
-  setEvents: React.Dispatch<React.SetStateAction<{}>>,
-  operation: any,
-  startedDateTime: any,
-  time: any,
-  timings: any,
-) {
-  // console.log('getApolloClient called with cacheId', cacheId);
-  chrome.tabs.query({active: true}, function getClientData(tabs) {
-    // console.log('getApolloClient executing tabs.query with tabs', tabs);
-    if (tabs.length) {
-      // console.log('getApolloClient sending message to get cahce');
-      chrome.tabs.sendMessage(tabs[0].id, {
-        type: 'GET_CACHE',
-        cacheId,
-      });
-      // console.log('getApolloClient setting Event with operation, timing, etc');
-      setEvents(evnts => {
-        // console.log('getApolloClient current evnts is', evnts);
-        // console.log(
-        //   'getApolloClient setEvent with cacheId, operation',
-        //   cacheId,
-        //   operation,
-        // );
-        const rstEvent = {
-          ...evnts,
-          [cacheId]: {
-            operation,
-            startedDateTime,
-            time,
-            timings,
-            cache: {},
-          },
-        };
-        return rstEvent;
-      });
-    }
-  });
-}
+
+// Listens for network events and filters them only for GraphQL requests
+// Currently only looks for queries and mutations
 export default function createNetworkListener(
   requestURI: string,
   setEvents: React.Dispatch<React.SetStateAction<{}>>,
 ) {
   chrome.devtools.network.onRequestFinished.addListener((httpReq: any) => {
+    // We only want to listen for GraphQL events to the Apollo Client URI
+    // and POST methods, ignoring any other events
     if (
       httpReq.request.url === requestURI &&
       httpReq.request.method === 'POST'
@@ -79,7 +49,10 @@ export default function createNetworkListener(
 
       // Generate some unique metaData to correlate the GraphQL network request
       // with the Apollo Client data.
-      const cacheId = new Date(startedDateTime).getTime();
+      // The cacheId will store the unix Epoch time of the GraphQL network request
+      // It will act as the key in the Events object where the cache and
+      // related data will be stored
+      const cacheId = new Date(startedDateTime).getTime().toString();
 
       // Filter for GraphQL queries and mutations
       // TODO: Listen for subscription events
@@ -93,15 +66,24 @@ export default function createNetworkListener(
         // the parse respsone data in our events object
         getNetworkResponsePayload(httpReq, setEvents, cacheId);
 
+        // Store all other related data to the Events object first while we wait for
+        // a message back from the contentScript with the actual cache itself
+        setEvents(evnts => {
+          const rstEvent = {
+            ...evnts,
+            [cacheId]: {
+              operation,
+              startedDateTime,
+              time,
+              timings,
+              cache: {},
+            },
+          };
+          return rstEvent;
+        });
+
         // Send a message to the content script to get the cache from the Apollo Client
-        getApolloClient(
-          cacheId,
-          setEvents,
-          operation,
-          startedDateTime,
-          time,
-          timings,
-        );
+        getApolloClient(cacheId);
       }
     }
   });

--- a/src/extension/contentScript.ts
+++ b/src/extension/contentScript.ts
@@ -4,18 +4,26 @@ interface IApolloClientHook {
   Apollo11Client: any;
 }
 
+// This code will be injected into the DOM of the website
+// It will set up an interval timer to try and detect the Apollo Client object
+// every 1000ms.  Once it finds it, the interval timer will be cleared
+//
+// The cacheId will be null if this is very first time we are injecting this script
+// Otherwise, it will contain the pre-generated unix Epoch time of a GraphQL network event
 function detectApolloClient(window: any, cacheId: string = null) {
   const apolloClientHook: IApolloClientHook = {
     Apollo11Client: null,
   };
 
-  console.log('Detect Apollo Client with :: ', cacheId);
+  // console.log('Detect Apollo Client with :: ', cacheId);
 
   // Need to add this eslint global to mitigate the following error:
   //   22:26  error    'NodeJS' is not defined       no-undef
   /* global NodeJS */
   let detectionInterval: NodeJS.Timeout;
 
+  // Helper function to actually detect the Apollo Client
+  // This function will be executed by the interval timer
   function findApolloClient() {
     if (window.__APOLLO_CLIENT__) {
       apolloClientHook.Apollo11Client = window.__APOLLO_CLIENT__;
@@ -25,6 +33,8 @@ function detectApolloClient(window: any, cacheId: string = null) {
         apolloClientHook.Apollo11Client,
       );
 
+      // Send a message from the injected script to the contentScript
+      // with the Apollo Client URI and the Apollo Client cache
       window.postMessage(
         {
           cacheId,
@@ -65,15 +75,18 @@ chrome.runtime.sendMessage({message: 'hello from bg'}, function (response) {
 
 // chrome.runtime.connect();
 
-// add listener
-
+// Listen for messages from the App
+// If a message to get the cache is received, it will inject the detection code
 chrome.runtime.onMessage.addListener(request => {
-  console.log('Request :: ', request);
+  console.log('contentScript message received with request :: ', request);
   if (request && request.type && request.type === 'GET_CACHE') {
     injectScript(request.cacheId);
   }
 });
 
+// Listen for messages from the injected script
+// Once a message is received, it will send a message to the App
+// with the Apollo Client URI and cache
 window.addEventListener(
   'message',
   function sendClientData(event) {
@@ -81,7 +94,7 @@ window.addEventListener(
     if (event.source !== window) return;
 
     if (event.data.type && event.data.type === 'FROM_PAGE') {
-      // send the apolloclient URI to the React app
+      // send the apolloclient URI and cache to the App
       chrome.runtime.sendMessage({
         message: event.data.text,
         apolloURI: event.data.apolloURI,
@@ -93,4 +106,8 @@ window.addEventListener(
   false,
 );
 
+// Immediately inject the detection code once the contentScript is loaded every time
+// we navigate to a new website
+// This mitigates issues where the App panel has already mounted and sent its initial
+// requests for the URI and cache, but there isn't any website loaded yet (i.e. empty tab)
 injectScript();


### PR DESCRIPTION
**Feature**:
Fix the messaging logic between the App and the contentScript code

**Description**:
- Refactor the getApolloClient function so that it only sends a message to the contentScript.  The code to update the Events object with the network-related data was moved back directly to the network listener.
- Due to this refactor, we can now move the getApolloClient from the networking.ts file to the messaging.ts file.  This was done so that the App can also use getApolloClient to get the cache rather than purely rely on network events
- The App itself will now invoke getApolloClient once it is mounted, rather than only wait until the contentScript is loaded independently.  This will send a message to the contentScript to get the initial URI and cache.  This was done to mitigate some scenarios described in the Test section below.
- Fix the inconsistency in cacheId type so it's always a string type

**How to test**:
- Load the extension and try different scenarios such as:
1) Open a new tab and navigate to a test website first, and then open the devtools panel
2) Open a new tab and open the devtools panel first, and then navigate to a test website

In any scenario above, check that the URI is populated automatically.  Inspect the panel console messages showing the Events object, which should contain the initial cache.

Perform some GraphQL operations and observe that the Events object is updated with new data.

Close and re-open the devtools panel and ensure the URI is automatically populated, along with an initial cache.  Perform some more GraphQL operations to ensure everything is still updating properly
