### PR TITLE
Send more performance data (timings, size) and mitigate detection of endpoint where URI is not available

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -5,33 +5,29 @@ import createURICacheListener, {getApolloClient} from './utils/messaging';
 import createNetworkListener from './utils/networking';
 
 const App = () => {
-  const [requestURI, setRequestURI] = useState('');
+  const [apolloURI, setApolloURI] = useState('');
   const [events, setEvents] = useState({});
 
+  // Only create the listener when the App is initially mounted
   useEffect(() => {
-    // Only create the listener when the App is initially mounted
-    // i.e., when the requestURI is empty
-    // Otherwise we will be creating multiple listeners
-    if (requestURI === '') {
-      // Event listener to obtain the GraphQL server endpoint (URI)
-      // and the cache from the Apollo Client
-      createURICacheListener(setRequestURI, setEvents);
+    // Event listener to obtain the GraphQL server endpoint (URI)
+    // and the cache from the Apollo Client
+    createURICacheListener(setApolloURI, setEvents);
 
-      // Initial load of the App, so send a message to the contentScript to get the cache
-      getApolloClient();
-    } else {
-      // Listen for network events only when we have a valid Apollo Client URI
-      createNetworkListener(requestURI, setEvents);
-    }
-  }, [requestURI]);
+    // Initial load of the App, so send a message to the contentScript to get the cache
+    getApolloClient();
+
+    // Listen for network events only when we have a valid Apollo Client URI
+    createNetworkListener(setApolloURI, setEvents);
+  }, []);
 
   useEffect(() => {
-    console.log('Current Event Log: ', events);
+    console.log('Current Event Log :>>', events);
   }, [events]);
 
   return (
     <div>
-      <MainDrawer endpointURI={requestURI} />
+      <MainDrawer endpointURI={apolloURI} />
     </div>
   );
 };

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -14,7 +14,7 @@ export default function createURICacheListener(
     // Don't set the apolloURI if the request.apolloURI is empty
     // This can happen if we aren't able to get it from the Apollo Client object
     // i.e., it uses an Apollo Link
-    // In that case, the network listener will set it the URI using the request.url,
+    // In that case, the network listener will set the URI using the request.url,
     // so we don't want to overwrite it here
     if (request.apolloURI !== '') {
       setApolloURI(request.apolloURI);

--- a/src/app/utils/networking.ts
+++ b/src/app/utils/networking.ts
@@ -9,7 +9,7 @@ export default function createNetworkListener(
   setEvents: React.Dispatch<React.SetStateAction<{}>>,
 ) {
   chrome.devtools.network.onRequestFinished.addListener((httpReq: any) => {
-    console.log('Network Request :>> ', httpReq);
+    // console.log('Network Request :>> ', httpReq);
 
     const operation = httpReq.request.postData
       ? JSON.parse(httpReq.request.postData.text)

--- a/src/app/utils/networking.ts
+++ b/src/app/utils/networking.ts
@@ -9,7 +9,7 @@ export default function createNetworkListener(
   setEvents: React.Dispatch<React.SetStateAction<{}>>,
 ) {
   chrome.devtools.network.onRequestFinished.addListener((httpReq: any) => {
-    // console.log('Network Request: ', httpReq);
+    console.log('Network Request :>> ', httpReq);
 
     const operation = httpReq.request.postData
       ? JSON.parse(httpReq.request.postData.text)

--- a/src/app/utils/networking.ts
+++ b/src/app/utils/networking.ts
@@ -2,89 +2,83 @@ import React from 'react';
 
 import {getApolloClient} from './messaging';
 
-// The response payload is not immediately available on the httpReq object
-// i.e., you can't simply get it using httpReq.response.content
-// Instead, you have to invoke the httpReq.getContent() method
-function getNetworkResponsePayload(
-  httpReq: any,
-  setEvents: React.Dispatch<React.SetStateAction<{}>>,
-  cacheId: string,
-) {
-  // console.log('getNetworkResponsePayload called with cacheId', cacheId);
-  httpReq.getContent((content: string) => {
-    const response = JSON.parse(content);
-    setEvents((prevEvents: any) => {
-      const newEvents = prevEvents;
-      // console.log('getNetworkResponsePayload prevEvents is', prevEvents);
-      if (newEvents[cacheId]) {
-        // console.log('getResponsePayload - cacheId exists');
-        newEvents[cacheId].response = response;
-      } else {
-        // console.log('getResponsePayload - cacheId does not exist');
-        newEvents[cacheId] = {response};
-      }
-      return newEvents;
-    });
-  });
-}
-
 // Listens for network events and filters them only for GraphQL requests
 // Currently only looks for queries and mutations
 export default function createNetworkListener(
-  requestURI: string,
+  setApolloURI: React.Dispatch<React.SetStateAction<{}>>,
   setEvents: React.Dispatch<React.SetStateAction<{}>>,
 ) {
   chrome.devtools.network.onRequestFinished.addListener((httpReq: any) => {
-    // We only want to listen for GraphQL events to the Apollo Client URI
-    // and POST methods, ignoring any other events
+    // console.log('Network Request: ', httpReq);
+
+    const operation = httpReq.request.postData
+      ? JSON.parse(httpReq.request.postData.text)
+      : null;
+
+    // Filter for GraphQL queries and mutations
+    // TODO: Listen for subscription events
     if (
-      httpReq.request.url === requestURI &&
-      httpReq.request.method === 'POST'
+      operation &&
+      operation.query &&
+      (operation.query.startsWith('query') ||
+        operation.query.startsWith('mutation'))
     ) {
-      // console.log('GraphQL Network Request: ', httpReq);
-
-      // Save the actual GraphQL request-related data we just detected
-      const operation = JSON.parse(httpReq.request.postData.text);
       const {startedDateTime, time, timings} = httpReq;
+      const request = {
+        bodySize: httpReq.request.bodySize,
+        headerSize: httpReq.request.headersSize,
+        method: httpReq.request.method,
+        operation,
+        url: httpReq.request.url,
+      };
+      const response = {
+        bodySize: httpReq.response.bodySize,
+        headersSize: httpReq.response.headersSize,
+      };
 
-      // Generate some unique metaData to correlate the GraphQL network request
-      // with the Apollo Client data.
-      // The cacheId will store the unix Epoch time of the GraphQL network request
+      console.log('Network listener saw GraphQL request :>> ', request);
+      console.log('Network listener saw GraphQL response :>> ', response);
+
+      console.log(
+        'Network listener updating apolloURI with network request.url :>>',
+        httpReq.request.url,
+      );
+      setApolloURI(httpReq.request.url);
+      // }
+
+      // The eventId will store the Unix epoch time of the GraphQL network request
       // It will act as the key in the Events object where the cache and
       // related data will be stored
-      const cacheId = new Date(startedDateTime).getTime().toString();
+      const eventId = new Date(startedDateTime).getTime().toString();
 
-      // Filter for GraphQL queries and mutations
-      // TODO: Listen for subscription events
-      if (
-        operation.query.startsWith('query') ||
-        operation.query.startsWith('mutation')
-      ) {
-        // The response from the GraphQL request is not immediately available
-        // Have to invoke the getContent() method to obtain this
-        // The callback is asynchronous so we will use our setEvents hook to store
-        // the parse respsone data in our events object
-        getNetworkResponsePayload(httpReq, setEvents, cacheId);
-
-        // Store all other related data to the Events object first while we wait for
-        // a message back from the contentScript with the actual cache itself
-        setEvents(evnts => {
-          const rstEvent = {
-            ...evnts,
-            [cacheId]: {
-              operation,
-              startedDateTime,
-              time,
-              timings,
-              cache: {},
-            },
-          };
-          return rstEvent;
+      console.log(
+        'Network listener updating Events with request/response data for eventId :>>',
+        eventId,
+      );
+      // The response from the GraphQL request is not immediately available
+      // Have to invoke the getContent() method to obtain this
+      httpReq.getContent((content: string) => {
+        setEvents((prevEvents: any) => {
+          const events = {...prevEvents};
+          if (!events[eventId]) events[eventId] = {};
+          events[eventId].request = request;
+          events[eventId].response = response;
+          events[eventId].response.content = JSON.parse(content);
+          events[eventId].response.content.size = httpReq.response.content.size;
+          events[eventId].startedDateTime = startedDateTime;
+          events[eventId].time = time;
+          events[eventId].timings = timings;
+          return events;
         });
+      });
 
-        // Send a message to the content script to get the cache from the Apollo Client
-        getApolloClient(cacheId);
-      }
+      // Send a message to the content script to get the cache from the Apollo Client
+      console.log(
+        'Network listener sending message to get Apollo Client for eventId :>>',
+        eventId,
+      );
+      getApolloClient(eventId);
     }
+    // }
   });
 }


### PR DESCRIPTION
**Feature:**
Send additional performance metrics with each network event and resolve scenario where URI is not detected on the Apollo Client instance.

**Description:**
- We now send additional performance metrics, e.g. request/response payload size (total, per resolver, etc).  This will be stored on the `bodySize` and `headersSize` properties on both the `request` and `response` objects.
- In cases where we can't detect the URI, we're now properly saving it based on the network request itself
- Renamed `requestURI` to `apolloURI`
- Renamed `cacheId` to `eventId`
- Refactored the messaging to simplify creation / handling of listeners so that it is not dependent on anything, i.e. only creates it once, not each time based on the URI like previously
- Refactored how we send the network payload in one callback vs multiple like previously

**How to Test:**
- Launch a test website and open the app panel
- Run some queries / mutations and inspect the panel for console.log messages for the Event log
