### PR TITLE
Performance - Proof of Concept

### DIFF
--- a/src/app/MainDrawer.tsx
+++ b/src/app/MainDrawer.tsx
@@ -101,9 +101,10 @@ const useStyles = makeStyles((theme: Theme) =>
 
 type MainDrawerProps = {
   endpointURI: string;
+  events: any;
 };
 
-export default function MainDrawer({endpointURI}: MainDrawerProps) {
+export default function MainDrawer({endpointURI, events}: MainDrawerProps) {
   const classes = useStyles();
   const theme = useTheme();
   const [open, setOpen] = useState(false);
@@ -131,7 +132,7 @@ export default function MainDrawer({endpointURI}: MainDrawerProps) {
       case 'Queries':
         return <Queries />;
       case 'Performance':
-        return <Performance />;
+        return <Performance events={events} />;
       default:
         return <GraphiQL endpointURI={endpointURI} />;
     }

--- a/src/app/Performance.tsx
+++ b/src/app/Performance.tsx
@@ -37,15 +37,15 @@ function Performance({events}: IPerformanceData) {
   const [selectedIndex, setSelectedIndex] = React.useState(0);
 
   const handleListItemClick = (event: any, index: number, key: string) => {
-    console.log('Selected Query Event :: ', event);
+    console.log('Selected Query Event :: ', event, ' with key => ', key);
     setSelectedIndex(index);
   };
   // console.log('Performance Data :: ', events);
   return (
     <div className={componentClass.root}>
-      <List component="nav" aria-label="main mailbox folders" dense={true}>
+      <List component="nav" aria-label="main mailbox folders" dense>
         {Object.entries(events)
-          .filter(([key, obj]: any) => obj && (obj.response || obj.request))
+          .filter(([, obj]: any) => obj && (obj.response || obj.request))
           .map(([key, obj]: any, k: number) => {
             const newobj = {
               operation:
@@ -54,11 +54,12 @@ function Performance({events}: IPerformanceData) {
                 obj.request.operation &&
                 obj.request.operation.operationName
                   ? obj.request.operation.operationName
-                  : 'Query', //stripNameFromRequest(obj.request.operation),
+                  : 'Query', // stripNameFromRequest(obj.request.operation),
               time: obj.time,
             };
             return (
               <ListItem
+                key={`operation${key}`}
                 className={`${componentClass.root}`}
                 selected={selectedIndex === k}
                 onClick={event => handleListItemClick(event, k, key)}>
@@ -67,10 +68,9 @@ function Performance({events}: IPerformanceData) {
             );
           })}
       </List>
-      <List
-        component="nav"
-        aria-label="main mailbox folders"
-        dense={true}></List>
+      <List component="nav" aria-label="main mailbox folders" dense>
+        Operation Details List
+      </List>
       {/* <Grid item xs={8} className={componentClass.grid}>
           Show content details
         </Grid>

--- a/src/app/Performance.tsx
+++ b/src/app/Performance.tsx
@@ -1,17 +1,80 @@
 import React from 'react';
-
-import useClientEventlogs from './utils/useClientEventlogs';
+import {makeStyles, createStyles, Theme} from '@material-ui/core/styles';
+// import Grid from '@material-ui/core/Grid';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+// import Divider from '@material-ui/core/Divider';
+// import useClientEventlogs from './utils/useClientEventlogs';
 
 interface IPerformanceData {
   events: any;
 }
 
+// setup component class hook
+const useStyles: any = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      flexGrow: 1,
+    },
+    grid: {
+      borderStyle: 'solid',
+      height: '100vh',
+      size: '2px',
+    },
+    paper: {
+      padding: theme.spacing(0),
+      textAlign: 'center',
+      color: theme.palette.text.primary,
+    },
+  }),
+);
+
 function Performance({events}: IPerformanceData) {
-  const data = useClientEventlogs();
-  console.log('Performance Data :: ', data);
+  // const data = useClientEventlogs();
+  const componentClass = useStyles();
+
+  const [selectedIndex, setSelectedIndex] = React.useState(0);
+
+  const handleListItemClick = (event: any, index: number, key: string) => {
+    console.log('Selected Query Event :: ', event);
+    setSelectedIndex(index);
+  };
+  // console.log('Performance Data :: ', events);
   return (
-    <div>
-      <p>This is the performance tab</p>
+    <div className={componentClass.root}>
+      <List component="nav" aria-label="main mailbox folders" dense={true}>
+        {Object.entries(events)
+          .filter(([key, obj]: any) => obj && (obj.response || obj.request))
+          .map(([key, obj]: any, k: number) => {
+            const newobj = {
+              operation:
+                obj &&
+                obj.request &&
+                obj.request.operation &&
+                obj.request.operation.operationName
+                  ? obj.request.operation.operationName
+                  : 'Query', //stripNameFromRequest(obj.request.operation),
+              time: obj.time,
+            };
+            return (
+              <ListItem
+                className={`${componentClass.root}`}
+                selected={selectedIndex === k}
+                onClick={event => handleListItemClick(event, k, key)}>
+                <ListItemText primary={`${newobj.operation} ${newobj.time}`} />
+              </ListItem>
+            );
+          })}
+      </List>
+      <List
+        component="nav"
+        aria-label="main mailbox folders"
+        dense={true}></List>
+      {/* <Grid item xs={8} className={componentClass.grid}>
+          Show content details
+        </Grid>
+      </Grid> */}
     </div>
   );
 }

--- a/src/app/Performance.tsx
+++ b/src/app/Performance.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 
-function Performance() {
+import useClientEventlogs from './utils/useClientEventlogs';
+
+interface IPerformanceData {
+  events: any;
+}
+
+function Performance({events}: IPerformanceData) {
+  const data = useClientEventlogs();
+  console.log('Performance Data :: ', data);
   return (
     <div>
       <p>This is the performance tab</p>

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -4,6 +4,8 @@ import MainDrawer from './MainDrawer';
 import createURICacheListener, {getApolloClient} from './utils/messaging';
 import createNetworkListener from './utils/networking';
 
+import useClientEventlogs from './utils/useClientEventlogs';
+
 const App = () => {
   const [apolloURI, setApolloURI] = useState('');
   const [events, setEvents] = useState({});
@@ -21,13 +23,16 @@ const App = () => {
     createNetworkListener(setApolloURI, setEvents);
   }, []);
 
+  useClientEventlogs(events);
+
   useEffect(() => {
     console.log('Current Event Log :>>', events);
+    // dump in hook
   }, [events]);
 
   return (
     <div>
-      <MainDrawer endpointURI={apolloURI} />
+      <MainDrawer endpointURI={apolloURI} events={events} />
     </div>
   );
 };

--- a/src/app/utils/useClientEventlogs.ts
+++ b/src/app/utils/useClientEventlogs.ts
@@ -1,0 +1,18 @@
+import React from 'react';
+
+// interface IApolloEventLog {
+//   [key: string]: any;
+// }
+
+const useClientEventlogs = (evts?: any) => {
+  const [eventLogs, updateEventLogs] = React.useState(() => {});
+  React.useEffect(() => {
+    if (evts) {
+      console.log('updating hook wt ', evts);
+      updateEventLogs(evts);
+    }
+  }, [evts]);
+  return eventLogs;
+};
+
+export default useClientEventlogs;


### PR DESCRIPTION
Features
Performance tab proof of concept to show the network operations (i.e. based on the project's scope; queries and mutations) and the timelines as well as other network tracing metrics.

Description

Passed the event log as props from the app component to its child components
currently using a list (Material Design) to list all operations occurring within the context of an apollo client session
Filter out the first operation log as that contains on the initial startup cache.
N.B: We still need to figure out how to handle situations when the apollo client used by the client in the web browser has tracing disabled. This gives little information at the moment, only when apollo client is instantiated with enabled tracing do we have more networking details to show.

How to test
- Launch a test website and open the app panel
- Run some queries/mutations, open the Performance tab, and observe the population of operations.