### PR TITLE
Performance Tab - Respond to Event Selection

### DIFF
--- a/src/app/Performance.tsx
+++ b/src/app/Performance.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import {makeStyles, createStyles, Theme} from '@material-ui/core/styles';
-// import Grid from '@material-ui/core/Grid';
+import Grid from '@material-ui/core/Grid';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 // import Divider from '@material-ui/core/Divider';
 // import useClientEventlogs from './utils/useClientEventlogs';
+
+import {extractOperationName} from './utils/helper';
 
 interface IPerformanceData {
   events: any;
@@ -31,11 +33,9 @@ const useStyles: any = makeStyles((theme: Theme) =>
 );
 
 function Performance({events}: IPerformanceData) {
-  // const data = useClientEventlogs();
   const componentClass = useStyles();
 
   const [selectedIndex, setSelectedIndex] = React.useState(0);
-
   const handleListItemClick = (event: any, index: number, key: string) => {
     console.log('Selected Query Event :: ', event, ' with key => ', key);
     setSelectedIndex(index);
@@ -43,38 +43,46 @@ function Performance({events}: IPerformanceData) {
   // console.log('Performance Data :: ', events);
   return (
     <div className={componentClass.root}>
-      <List component="nav" aria-label="main mailbox folders" dense>
-        {Object.entries(events)
-          .filter(([, obj]: any) => obj && (obj.response || obj.request))
-          .map(([key, obj]: any, k: number) => {
-            const newobj = {
-              operation:
-                obj &&
-                obj.request &&
-                obj.request.operation &&
-                obj.request.operation.operationName
-                  ? obj.request.operation.operationName
-                  : 'Query', // stripNameFromRequest(obj.request.operation),
-              time: obj.time,
-            };
-            return (
-              <ListItem
-                key={`operation${key}`}
-                className={`${componentClass.root}`}
-                selected={selectedIndex === k}
-                onClick={event => handleListItemClick(event, k, key)}>
-                <ListItemText primary={`${newobj.operation} ${newobj.time}`} />
-              </ListItem>
-            );
-          })}
-      </List>
-      <List component="nav" aria-label="main mailbox folders" dense>
-        Operation Details List
-      </List>
-      {/* <Grid item xs={8} className={componentClass.grid}>
-          Show content details
+      <Grid container spacing={0}>
+        <Grid item xs={4} className={componentClass.grid}>
+          <List component="nav" aria-label="main mailbox folders" dense>
+            {Object.entries(events)
+              .filter(([, obj]: any) => obj && (obj.response || obj.request))
+              .map(([key, obj]: any, k: number) => {
+                // console.log(
+                //   'Pluck Fisrt of above :: ',
+                //   extractOperationName(obj),
+                // );
+                const newobj = {
+                  operation:
+                    obj &&
+                    obj.request &&
+                    obj.request.operation &&
+                    obj.request.operation.operationName
+                      ? obj.request.operation.operationName
+                      : extractOperationName(obj),
+                  time: obj.time,
+                };
+                return (
+                  <ListItem
+                    key={`operation${key}`}
+                    className={`${componentClass.root}`}
+                    selected={selectedIndex === k}
+                    onClick={event => handleListItemClick(event, k, key)}>
+                    <ListItemText
+                      primary={`${newobj.operation} ${newobj.time}`}
+                    />
+                  </ListItem>
+                );
+              })}
+          </List>
         </Grid>
-      </Grid> */}
+        <Grid item xs={8} className={componentClass.grid}>
+          <List component="nav" aria-label="main mailbox folders" dense>
+            Operation Details List
+          </List>
+        </Grid>
+      </Grid>
     </div>
   );
 }

--- a/src/app/Performance.tsx
+++ b/src/app/Performance.tsx
@@ -67,6 +67,7 @@ function Performance({events}: IPerformanceData) {
           };
           // need to transform resolvers in Array
           console.log('Go utilize this tracing Data :: ', tracingData);
+          // TODO: Transform resolvers ordering by startOffset and hopeful format to show in the details list on a waterfall model
         }
       }
     }

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -4,8 +4,6 @@ import MainDrawer from './MainDrawer';
 import createURICacheListener, {getApolloClient} from './utils/messaging';
 import createNetworkListener from './utils/networking';
 
-import useClientEventlogs from './utils/useClientEventlogs';
-
 const App = () => {
   const [apolloURI, setApolloURI] = useState('');
   const [events, setEvents] = useState({});
@@ -22,8 +20,6 @@ const App = () => {
     // Listen for network events only when we have a valid Apollo Client URI
     createNetworkListener(setApolloURI, setEvents);
   }, []);
-
-  useClientEventlogs(events);
 
   useEffect(() => {
     console.log('Current Event Log :>>', events);

--- a/src/app/utils/helper.ts
+++ b/src/app/utils/helper.ts
@@ -24,7 +24,8 @@ export function pluck(
 
 /**
  * Extract the name of a query request or mutation using the query passed to the grapqql server
- * @param operation
+ * @param operation The request operation object from the network request object
+ * Returns a string or null if not avaialable and in some cases a null if the request object has no query passed
  */
 export function extractOperationName(operation: any): string {
   const operate =
@@ -32,10 +33,8 @@ export function extractOperationName(operation: any): string {
     operation.request &&
     operation.request.operation &&
     operation.request.operation.query
-      ? pluck(operation.request.operation.query.split('('))
+      ? pluck(operation.request.operation.query.split('(')) // pluck the first item from the array after the query is split using '(' as teh delimter
       : null;
-  console.log('Initial Extracted Operation :: ', operate);
-  if (!operate) return 'Query';
-  console.log('End to Pluck from :: ', operate.split(' '));
-  return pluck(operate.split(' '), DIRECTION.END, '');
+  if (!operate) return 'Query'; // return a constant response 'Query' if the when the query was split, there was no item(s) in the array
+  return pluck(operate.split(' '), DIRECTION.END, ''); // pluck the last item from the 'operate' array, this will definitely be the name of the operation form the query passed to the graphql server
 }

--- a/src/app/utils/helper.ts
+++ b/src/app/utils/helper.ts
@@ -1,0 +1,30 @@
+/**
+ * An enumerator for the DIRECTION of item to pluck from an Array mainly FIRST or LAST
+ */
+enum DIRECTION {
+  FRONT,
+  END,
+}
+
+/**
+ *
+ * @param inputArray input Array of strings
+ * @param position  the position to pluck
+ * @param defaultValue a default value to return when position of the array does not exist
+ */
+export function pluck(
+  inputArray: string[],
+  position: DIRECTION = 0,
+  defaultValue: any = undefined,
+): any {
+  return inputArray && inputArray.length
+    ? inputArray[position === DIRECTION.FRONT ? 0 : inputArray.length - 1]
+    : defaultValue;
+}
+
+export function extractOpertionName(operation: string): string {
+  let operate = operation ? pluck(operation.split('(')) : null;
+  console.log('Initial Extracted Operation :: ', operate);
+  if (!operate) return 'Query';
+  return pluck(operation.split(' '), DIRECTION.END, '');
+}

--- a/src/app/utils/helper.ts
+++ b/src/app/utils/helper.ts
@@ -22,9 +22,20 @@ export function pluck(
     : defaultValue;
 }
 
-export function extractOpertionName(operation: string): string {
-  let operate = operation ? pluck(operation.split('(')) : null;
+/**
+ * Extract the name of a query request or mutation using the query passed to the grapqql server
+ * @param operation
+ */
+export function extractOperationName(operation: any): string {
+  const operate =
+    operation &&
+    operation.request &&
+    operation.request.operation &&
+    operation.request.operation.query
+      ? pluck(operation.request.operation.query.split('('))
+      : null;
   console.log('Initial Extracted Operation :: ', operate);
   if (!operate) return 'Query';
-  return pluck(operation.split(' '), DIRECTION.END, '');
+  console.log('End to Pluck from :: ', operate.split(' '));
+  return pluck(operate.split(' '), DIRECTION.END, '');
 }

--- a/src/app/utils/useClientEventlogs.ts
+++ b/src/app/utils/useClientEventlogs.ts
@@ -4,15 +4,71 @@ import React from 'react';
 //   [key: string]: any;
 // }
 
-const useClientEventlogs = (evts?: any) => {
-  const [eventLogs, updateEventLogs] = React.useState(() => {});
-  React.useEffect(() => {
-    if (evts) {
-      console.log('updating hook wt ', evts);
-      updateEventLogs(evts);
-    }
-  }, [evts]);
-  return eventLogs;
+// import React, {createContext, FC, useContext, useEffect, useState} from 'react';
+
+// interface IViewport {
+//   width: number;
+// }
+
+// const ViewportContext = createContext<IViewport>({
+//   width: window.innerWidth,
+// });
+
+// // export const ViewportProvider: FC = ({ children }) => {
+// type Props = {
+//   children: React.ReactNode;
+// };
+// export const ViewportProvider = ({children}: Props) => {
+//   const [width, setWidth] = useState(window.innerWidth);
+
+//   const handleResize = () => setWidth(window.innerWidth);
+
+//   useEffect(() => {
+//     window.addEventListener('resize', handleResize);
+//     return () => window.removeEventListener('resize', handleResize);
+//   }, []);
+
+//   return (
+//     <ViewportContext.Provider value={{width}}>
+//       {children}
+//     </ViewportContext.Provider>
+//   );
+// };
+
+// export function useViewport() {
+//   return useContext<IViewport>(ViewportContext);
+// }
+
+// const defaultTheme = 'white';
+// const ThemeContext = React.createContext(defaultTheme);
+// type Props = {
+//   children: React.ReactNode;
+// };
+// export const ThemeProvider = ({children}: Props) => {
+//   const [theme, setTheme] = React.useState(defaultTheme);
+
+//   React.useEffect(() => {
+//     // We'd get the theme from a web API / local storage in a real app
+//     // We've hardcoded the theme in our example
+//     const currentTheme = 'lightblue';
+//     setTheme(currentTheme);
+//   }, []);
+
+//   return (
+//     <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
+//   );
+// };
+
+const useClientEventlogs = () => {
+  const [eventLogs, updateEventLogs] = React.useState((): any => ({}));
+  const updateLogs = (evts: any) => {
+    console.log('updating hook wt ', evts);
+    updateEventLogs((prevEvents: any) => {
+      console.log('Previous Events :: ', prevEvents);
+      return evts;
+    });
+  };
+  return {eventLogs, updateLogs};
 };
 
 export default useClientEventlogs;


### PR DESCRIPTION
**Features**
Added grid presentation layer for the event lists and details when an item is selected.
Added clickHandler to respond to an event when clicked to extract useful information for tracing/performance details
This is only at the stage of property key restructuring from the event log.

**Description**
We are now able to respond to the events selected in the grid to process the selected event. This will help to show the transformed data in the details tab.

**TODO**
Presentation layer to display the details of the performance when tracing is enabled in the graphql server and total timing when it is not
operationName helper method should return operation type as name when operation name does not exist on the request object
Other stretch features to restructure the property keys from event log object rather than re-assigning.

**How to test**
Launch a test website and open the app panel
Run some queries/mutations, open the Performance tab, and observe the population of operations.
Click the event log items and observe the console to see the data logged