### PR TITLE
align text left for event details json data

### DIFF
--- a/src/app/CacheDetails.tsx
+++ b/src/app/CacheDetails.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactJson from 'react-json-view';
+import Typography from '@material-ui/core/Typography';
 
 type CacheDetailsProps = {
   eventLog: any;
@@ -18,10 +19,12 @@ const CacheDetails = ({
 
       {eventLog[activeEvent] ? (
         <div>
-          <ReactJson
-            name={false}
-            src={eventLog[activeEvent].cache[activeCache]}
-          />
+          <Typography align="left">
+            <ReactJson
+              name={false}
+              src={eventLog[activeEvent].cache[activeCache]}
+            />
+          </Typography>
         </div>
       ) : (
         <div>No cache item selected</div>

--- a/src/app/EventDetails.tsx
+++ b/src/app/EventDetails.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactJson from 'react-json-view';
+import Typography from '@material-ui/core/Typography';
 
 type EventDetailsProps = {
   eventLog: any;
@@ -13,18 +14,20 @@ const EventDetails = ({activeEvent, eventLog}: EventDetailsProps) => {
       <h2>{activeEvent}</h2>
       {eventLog[activeEvent] ? (
         <div>
-          <h3>Operation</h3>
-          <ReactJson
-            name="operation"
-            src={eventLog[activeEvent].request.operation}
-            collapsed
-          />
-          <h3>Response</h3>
-          <ReactJson
-            name="response"
-            src={eventLog[activeEvent].response}
-            collapsed
-          />
+          <Typography align="left">
+            <h3>Operation</h3>
+            <ReactJson
+              name="operation"
+              src={eventLog[activeEvent].request.operation}
+              collapsed
+            />
+            <h3>Response</h3>
+            <ReactJson
+              name="response"
+              src={eventLog[activeEvent].response}
+              collapsed
+            />
+          </Typography>
         </div>
       ) : (
         <div>No event selected</div>

--- a/src/app/MainDrawer.tsx
+++ b/src/app/MainDrawer.tsx
@@ -185,21 +185,19 @@ export default function MainDrawer({endpointURI, events}: MainDrawerProps) {
         </div>
         <Divider />
         <List>
-          {['GraphiQL', 'Queries', 'Apollo Tab', 'Store', 'Performance'].map(
-            (text, index) => (
-              <ListItem
-                button
-                key={text}
-                onClick={() => {
-                  setActiveTab(`${text}`);
-                }}>
-                <ListItemIcon>
-                  {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-                </ListItemIcon>
-                <ListItemText primary={text} />
-              </ListItem>
-            ),
-          )}
+          {['GraphiQL', 'Apollo Tab', 'Performance'].map((text, index) => (
+            <ListItem
+              button
+              key={text}
+              onClick={() => {
+                setActiveTab(`${text}`);
+              }}>
+              <ListItemIcon>
+                {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+              </ListItemIcon>
+              <ListItemText primary={text} />
+            </ListItem>
+          ))}
         </List>
       </Drawer>
       <main className={classes.content}>


### PR DESCRIPTION
**Feature**:
Event details text alignment

**Description**:
- Modify the text alignment for the event details JSON view so that it justifies to the left
- Remove the Queries and Store tabs that are no longer used

**How to test:**
- Load the extension and navigate to a test website
- Observe that the text alignment for the event details is now left justified
