### PR TITLE
Use actionHookForDevTools to listen for GraphQL operations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
     'no-underscore-dangle': 'off',
     // 'no-useless-computed-key': 'off',
     // 'no-param-reassign': 'off',
+    'no-console': 'off',
     'import/extensions': [
       'error',
       'ignorePackages',

--- a/src/app/EventLog.tsx
+++ b/src/app/EventLog.tsx
@@ -31,15 +31,23 @@ const EventLog = ({eventLog, handleEventChange}: EventLogProps) => {
           // However, this should be a string anyway
           const eventString = event.toString();
 
+          // console.log('Event is :>> ', event);
+          // console.log('Eventlog[event] is :>> ', eventLog[event]);
+
           // if statement to handle key of 0 and undefined
           if (
             event === 0 ||
             event === undefined ||
             event === 'undefined' ||
+            event === 'queryIdCounter' ||
+            event === 'mutationIdCounter' ||
+            event === 'requestIdCounter' ||
+            event === 'idCounter' ||
+            event === 'lastEventId' ||
             !event ||
             event === '0' ||
-            eventString === '0' ||
-            !eventLog[event].request
+            eventString === '0'
+            // !eventLog[event].request
           ) {
             // if key is 0 or undefined, just log it to the console and return so the next lines of code don't run
             return console.log('Event === undefined', event);

--- a/src/app/MainDrawer.tsx
+++ b/src/app/MainDrawer.tsx
@@ -102,9 +102,16 @@ const useStyles = makeStyles((theme: Theme) =>
 type MainDrawerProps = {
   endpointURI: string;
   events: any;
+  networkEvents: any;
+  networkURI: string;
 };
 
-export default function MainDrawer({endpointURI, events}: MainDrawerProps) {
+export default function MainDrawer({
+  endpointURI,
+  events,
+  networkEvents,
+  networkURI,
+}: MainDrawerProps) {
   const classes = useStyles();
   const theme = useTheme();
   const [open, setOpen] = useState(false);
@@ -126,15 +133,15 @@ export default function MainDrawer({endpointURI, events}: MainDrawerProps) {
   const renderTab = (tab: string): React.ReactElement => {
     switch (tab) {
       case 'GraphiQL':
-        return <GraphiQL endpointURI={endpointURI} />;
+        return <GraphiQL endpointURI={endpointURI || networkURI} />;
       case 'Apollo Tab':
         return <ApolloTab eventLog={events} />;
       case 'Queries':
         return <Queries />;
       case 'Performance':
-        return <Performance events={events} />;
+        return <Performance networkEvents={networkEvents} />;
       default:
-        return <GraphiQL endpointURI={endpointURI} />;
+        return <GraphiQL endpointURI={endpointURI || networkURI} />;
     }
   };
 

--- a/src/app/Performance.tsx
+++ b/src/app/Performance.tsx
@@ -10,7 +10,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import {extractOperationName} from './utils/helper';
 
 interface IPerformanceData {
-  events: any;
+  networkEvents: any;
 }
 
 interface ITimings {
@@ -36,7 +36,7 @@ const useStyles: any = makeStyles((theme: Theme) =>
   }),
 );
 
-function Performance({events}: IPerformanceData) {
+function Performance({networkEvents}: IPerformanceData) {
   const componentClass = useStyles();
 
   const [selectedIndex, setSelectedIndex] = React.useState(0);
@@ -46,8 +46,8 @@ function Performance({events}: IPerformanceData) {
   const [tracingInfo, setTracingInfo] = React.useState({});
 
   const handleListItemClick = (event: any, index: number, key: string) => {
-    if (events[key]) {
-      let payload = events[key];
+    if (networkEvents[key]) {
+      let payload = networkEvents[key];
       if (payload && payload.response && payload.response.content) {
         // first level safety check
         payload = payload.response.content;
@@ -56,7 +56,7 @@ function Performance({events}: IPerformanceData) {
         if (!(payload && payload.extensions && payload.extensions.tracing)) {
           // let use know they need to activate Tracing Data when ApolloServer was instantiated on their server
           // events[key].time
-          setTimingsInfo({timings: events[key].time});
+          setTimingsInfo({timings: networkEvents[key].time});
         } else {
           // TODO Try destructing deeply nested
           const {duration, endTime, startTime} = payload.extensions.tracing;
@@ -117,9 +117,9 @@ function Performance({events}: IPerformanceData) {
     <div className={componentClass.root}>
       <Grid container spacing={0}>
         <Grid item xs={4} className={componentClass.grid}>
-          <h2>Events</h2>
+          <h2>Network Events</h2>
           <List component="nav" aria-label="main mailbox folders" dense>
-            {Object.entries(events)
+            {Object.entries(networkEvents)
               .filter(([, obj]: any) => obj && (obj.response || obj.request))
               .map(([key, obj]: any, k: number) => {
                 // console.log(

--- a/src/app/Performance.tsx
+++ b/src/app/Performance.tsx
@@ -55,8 +55,8 @@ function Performance({networkEvents}: IPerformanceData) {
   );
 
   const handleListItemClick = (event: any, index: number, key: string) => {
-    if (events[key]) {
-      const payload = events[key];
+    if (networkEvents[key]) {
+      const payload = networkEvents[key];
       if (payload && payload.response && payload.response.content) {
         // first level safety check
 

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -2,11 +2,13 @@ import React, {useState, useEffect} from 'react';
 
 import MainDrawer from './MainDrawer';
 import createURICacheEventListener, {getApolloClient} from './utils/messaging';
-import createNetworkListener from './utils/networking';
+import createNetworkEventListener from './utils/networking';
 
 const App = () => {
   const [apolloURI, setApolloURI] = useState('');
+  const [networkURI, setNetworkURI] = useState('');
   const [events, setEvents] = useState({});
+  const [networkEvents, setNetworkEvents] = useState({});
 
   // Only create the listener when the App is initially mounted
   useEffect(() => {
@@ -17,8 +19,8 @@ const App = () => {
     // Initial load of the App, so send a message to the contentScript to get the cache
     getApolloClient();
 
-    // Listen for network events only when we have a valid Apollo Client URI
-    createNetworkListener(setApolloURI);
+    // Listen for network events
+    createNetworkEventListener(setNetworkURI, setNetworkEvents);
   }, []);
 
   useEffect(() => {
@@ -26,9 +28,19 @@ const App = () => {
     // dump in hook
   }, [events]);
 
+  useEffect(() => {
+    console.log('Current Network Log :>>', networkEvents);
+    // dump in hook
+  }, [networkEvents]);
+
   return (
     <div>
-      <MainDrawer endpointURI={apolloURI} events={events} />
+      <MainDrawer
+        endpointURI={apolloURI}
+        events={events}
+        networkEvents={networkEvents}
+        networkURI={networkURI}
+      />
     </div>
   );
 };

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -75,6 +75,12 @@ export default function createURICacheEventListener(
       });
     } else {
       console.log('App got client data', request);
+
+      // Bail out if we don't see the v3 counters
+      // v2 has idCounter
+      // v3 has requestIdCounter, queryIdCounter, mutationIdCounter
+      if (request.queryManager.requestIdCounter === undefined) return;
+
       setEvents((prevEvents: any) => {
         const newEvents = {...prevEvents};
         let {eventId} = request;
@@ -101,10 +107,14 @@ export default function createURICacheEventListener(
 
         // Check if this event is a new query
         if (queryManager.queryIdCounter > prevEvents.queryIdCounter) {
-          // console.log(
-          //   'queryManager.queryIdCounter :>> ',
-          //   queryManager.queryIdCounter,
-          // );
+          console.log(
+            'queryManager.queryIdCounter :>> ',
+            queryManager.queryIdCounter,
+          );
+          console.log(
+            'queryManager.queriesStore :>> ',
+            queryManager.queriesStore,
+          );
 
           event.request.operation = {
             operationName:
@@ -117,10 +127,14 @@ export default function createURICacheEventListener(
           event.response.content = 'query';
         } else {
           // event is a new mutation
-          // console.log(
-          //   'queryManager.mutationIdCounter :>> ',
-          //   queryManager.mutationIdCounter,
-          // );
+          console.log(
+            'queryManager.mutationIdCounter :>> ',
+            queryManager.mutationIdCounter,
+          );
+          console.log(
+            'queryManager.mutationStore :>> ',
+            queryManager.mutationStore,
+          );
 
           event.request.operation = {
             operationName:

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -14,25 +14,25 @@ export default function createURICacheEventListener(
     // Ignore any messages from contentScripts that aren't on the same tab
     // as the currently open Apollo devtools tab
     if (tabId !== sender.tab.id) {
-      console.log(
-        'App on tabId :>>',
-        tabId,
-        'ignoring message from sender :>>',
-        sender.tab.id,
-      );
+      // console.log(
+      //   'App on tabId :>>',
+      //   tabId,
+      //   'ignoring message from sender :>>',
+      //   sender.tab.id,
+      // );
 
       // sendResponse(`App on ${tabId} ignoring message from ${sender.tab.id}`);
       return;
     }
 
-    console.log(
-      'App on tabId :>>',
-      tabId,
-      'accepting message :>>',
-      request,
-      'from sender :>>',
-      sender.tab.id,
-    );
+    // console.log(
+    //   'App on tabId :>>',
+    //   tabId,
+    //   'accepting message :>>',
+    //   request,
+    //   'from sender :>>',
+    //   sender.tab.id,
+    // );
 
     sendResponse(`App on ${tabId} accepting message from ${sender.tab.id}`);
 
@@ -67,12 +67,12 @@ export default function createURICacheEventListener(
       newEvents[eventId] = {...prevEvents[eventId], ...event};
       newEvents[eventId].cache = request.apolloCache;
 
-      console.log(
-        'App on tabId :>>',
-        tabId,
-        'createURICacheEventListener setEvent :>>',
-        newEvents,
-      );
+      // console.log(
+      //   'App on tabId :>>',
+      //   tabId,
+      //   'createURICacheEventListener setEvent :>>',
+      //   newEvents,
+      // );
 
       return newEvents;
     });
@@ -86,13 +86,13 @@ export function getApolloClient(eventId: string = 'null', event: any = null) {
   // Get the active tab and send a message to the contentScript to get the cache
   chrome.tabs.query({active: true}, function getClientData(tabs) {
     if (tabs.length) {
-      console.log(
-        'App on tabId :>>',
-        chrome.devtools.inspectedWindow.tabId,
-        'sending message to tabId :>>',
-        tabs[0].id,
-        'to GET_CACHE',
-      );
+      // console.log(
+      //   'App on tabId :>>',
+      //   chrome.devtools.inspectedWindow.tabId,
+      //   'sending message to tabId :>>',
+      //   tabs[0].id,
+      //   'to GET_CACHE',
+      // );
 
       chrome.tabs.sendMessage(tabs[0].id, {
         type: 'GET_CACHE',

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -36,46 +36,118 @@ export default function createURICacheEventListener(
 
     sendResponse(`App on ${tabId} accepting message from ${sender.tab.id}`);
 
-    // Don't set the apolloURI if the request.apolloURI is empty
-    // This can happen if we aren't able to get it from the Apollo Client object
-    // i.e., it uses an Apollo Link
-    // In that case, the network listener will set the URI using the request.url,
-    // so we don't want to overwrite it here
-    if (request.apolloURI !== '') {
+    if (request.type === 'URI_CACHE') {
       setApolloURI(request.apolloURI);
+
+      setEvents((prevEvents: any) => {
+        const newEvents = {...prevEvents};
+        let {eventId} = request;
+        const {event} = request;
+
+        // Check if this is the initial message sent by the contentScript
+        // i.e., received without a pre-generated eventId,
+        // so set eventId to zero so it is the smallest value key in the events object
+        // This keeps the first cache sent to be chronologically the first one in the events object
+        if (eventId === 'null') {
+          // console.log('createURICacheEventListener eventId is null');
+          eventId = '0';
+        }
+
+        if (!newEvents[eventId]) {
+          // console.log('createURICacheEventListener eventId not found on events');
+          newEvents[eventId] = {};
+        }
+
+        newEvents[eventId] = {...prevEvents[eventId], ...event};
+        newEvents[eventId].cache = request.apolloCache;
+        newEvents.queryIdCounter = request.queryIdCounter;
+        newEvents.mutationIdCounter = request.mutationIdCounter;
+        newEvents.requestIdCounter = request.requestIdCounter;
+
+        // console.log(
+        //   'App on tabId :>>',
+        //   tabId,
+        //   'createURICacheEventListener setEvent :>>',
+        //   newEvents,
+        // );
+
+        return newEvents;
+      });
+    } else {
+      console.log('App got client data', request);
+      setEvents((prevEvents: any) => {
+        const newEvents = {...prevEvents};
+        let {eventId} = request;
+        const {queryManager} = request;
+
+        if (eventId === 'null') {
+          // console.log('eventId is null, setting to 0');
+          eventId = '0';
+        }
+
+        if (!newEvents[eventId]) {
+          // console.log('newEvents does not have eventId', eventId);
+          newEvents[eventId] = {};
+        }
+
+        const event: any = {};
+        event.request = {};
+        event.response = {};
+
+        // console.log(
+        //   'queryManager.requestIdCounter :>> ',
+        //   queryManager.requestIdCounter,
+        // );
+
+        // Check if this event is a new query
+        if (queryManager.queryIdCounter > prevEvents.queryIdCounter) {
+          // console.log(
+          //   'queryManager.queryIdCounter :>> ',
+          //   queryManager.queryIdCounter,
+          // );
+
+          event.request.operation = {
+            operationName:
+              queryManager.queriesStore[queryManager.queryIdCounter - 1]
+                .document.definitions[0].name.value,
+            query:
+              queryManager.queriesStore[queryManager.queryIdCounter - 1]
+                .document.loc.source.body,
+          };
+          event.response.content = 'query';
+        } else {
+          // event is a new mutation
+          // console.log(
+          //   'queryManager.mutationIdCounter :>> ',
+          //   queryManager.mutationIdCounter,
+          // );
+
+          event.request.operation = {
+            operationName:
+              queryManager.mutationStore.store[
+                queryManager.mutationIdCounter - 1
+              ].mutation.definitions[0].name.value,
+            query:
+              queryManager.mutationStore.store[
+                queryManager.mutationIdCounter - 1
+              ].mutation.loc.source.body,
+          };
+          event.response.content = 'mutation';
+        }
+
+        newEvents[eventId] = {...prevEvents[eventId], ...event};
+        newEvents[eventId].cache = request.cache;
+
+        // Update all of the counters
+        newEvents.requestIdCounter = queryManager.requestIdCounter;
+        newEvents.queryIdCounter = queryManager.queryIdCounter;
+        newEvents.mutationIdCounter = queryManager.mutationIdCounter;
+
+        // console.log('newEvents :>> ', newEvents);
+
+        return newEvents;
+      });
     }
-
-    setEvents((prevEvents: any) => {
-      const newEvents = {...prevEvents};
-      let {eventId} = request;
-      const {event} = request;
-
-      // Check if this is the initial message sent by the contentScript
-      // i.e., received without a pre-generated eventId,
-      // so set eventId to zero so it is the smallest value key in the events object
-      // This keeps the first cache sent to be chronologically the first one in the events object
-      if (eventId === 'null') {
-        // console.log('createURICacheEventListener eventId is null');
-        eventId = '0';
-      }
-
-      if (!newEvents[eventId]) {
-        // console.log('createURICacheEventListener eventId not found on events');
-        newEvents[eventId] = {};
-      }
-
-      newEvents[eventId] = {...prevEvents[eventId], ...event};
-      newEvents[eventId].cache = request.apolloCache;
-
-      // console.log(
-      //   'App on tabId :>>',
-      //   tabId,
-      //   'createURICacheEventListener setEvent :>>',
-      //   newEvents,
-      // );
-
-      return newEvents;
-    });
   });
 }
 

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -51,12 +51,14 @@ export default function createURICacheEventListener(
         // so set eventId to zero so it is the smallest value key in the events object
         // This keeps the first cache sent to be chronologically the first one in the events object
         if (eventId === 'null') {
-          // console.log('createURICacheEventListener eventId is null');
+          console.log('createURICacheEventListener eventId is null');
           eventId = '0';
         }
 
         if (!newEvents[eventId]) {
-          // console.log('createURICacheEventListener eventId not found on events');
+          console.log(
+            'createURICacheEventListener eventId not found on events',
+          );
           newEvents[eventId] = {};
         }
 
@@ -67,23 +69,26 @@ export default function createURICacheEventListener(
         newEvents.requestIdCounter = request.requestIdCounter;
         newEvents.lastEventId = eventId;
 
-        // console.log(
-        //   'App on tabId :>>',
-        //   tabId,
-        //   'createURICacheEventListener setEvent :>>',
-        //   newEvents,
-        // );
+        console.log(
+          'App on tabId :>>',
+          tabId,
+          'createURICacheEventListener setEvent :>>',
+          newEvents,
+        );
 
         return newEvents;
       });
     } else {
-      console.log('App got client data :>> ', request);
-
       // v2 has idCounter
       // v3 has requestIdCounter, queryIdCounter, mutationIdCounter
       // Bail out if we don't see the v3 counters for now
       // TODO: support v2 clients
-      if (request.queryManager.requestIdCounter === undefined) return;
+      if (request.queryManager.requestIdCounter === undefined) {
+        console.log('App ignoring v2 data', request);
+        return;
+      }
+
+      console.log('App got client data :>> ', request);
 
       setEvents((prevEvents: any) => {
         const newEvents = {...prevEvents};

--- a/src/app/utils/networking.ts
+++ b/src/app/utils/networking.ts
@@ -45,12 +45,17 @@ const getGraphQLOperation = (httpReq: any) => {
       if (keys.includes('operationName') || keys.includes('query')) {
         console.log('graphQL GET operation', operation, 'for URL', request.url);
       } else {
+        // console.log('graphQL GET has no operationName or query', operation);
         operation = null;
       }
     }
   }
 
-  if (!operation && request.url.includes('graphql')) {
+  if (
+    !operation &&
+    request.url.includes('graphql') &&
+    request.method !== 'OPTIONS'
+  ) {
     console.log('Ignoring potential graphql request', request);
   }
 

--- a/src/app/utils/networking.ts
+++ b/src/app/utils/networking.ts
@@ -75,13 +75,19 @@ export default function createNetworkEventListener(
 
     if (!operation) return;
 
+    const searchIndex = httpReq.request.url.indexOf('?');
+    const baseURL =
+      searchIndex !== -1
+        ? httpReq.request.url.slice(0, searchIndex)
+        : httpReq.request.url;
+
     const {startedDateTime, time, timings} = httpReq;
     const request = {
       bodySize: httpReq.request.bodySize,
       headersSize: httpReq.request.headersSize,
       method: httpReq.request.method,
       operation,
-      url: httpReq.request.url,
+      url: baseURL,
     };
     const response = {
       bodySize: httpReq.response.bodySize,

--- a/src/app/utils/networking.ts
+++ b/src/app/utils/networking.ts
@@ -3,7 +3,7 @@ import React from 'react';
 const getGraphQLOperation = (httpReq: any) => {
   // console.log('getGraphQLOperation parsing request', request);
 
-  const {request, response} = httpReq;
+  const {request} = httpReq;
   let operation;
 
   if (

--- a/src/app/utils/networking.ts
+++ b/src/app/utils/networking.ts
@@ -111,7 +111,7 @@ export default function createNetworkEventListener(
       event.request = request;
       event.response = response;
       event.response.content = JSON.parse(content);
-      if (event.response.content.size) {
+      if (httpReq.response.content.size) {
         event.response.content.size = httpReq.response.content.size;
       } else {
         console.log(

--- a/src/extension/contentScript.ts
+++ b/src/extension/contentScript.ts
@@ -98,8 +98,8 @@ chrome.runtime.onMessage.addListener((request, sender) => {
   console.log(
     'contentScript onMessage listener received request :>>',
     request,
-    'from sender.tab :>>',
-    sender.tab,
+    'from sender :>>',
+    sender,
   );
 
   if (request && request.type && request.type === 'GET_CACHE') {
@@ -113,22 +113,19 @@ chrome.runtime.onMessage.addListener((request, sender) => {
 window.addEventListener(
   'message',
   function sendClientData(event) {
-    console.log('contentScript window listener got event.data :>>', event.data);
+    // console.log('contentScript window listener got event.data :>>', event.data);
 
     // We only accept messages from ourselves
     if (event.source !== window) {
-      console.log(
-        'contentScript window listener ignoring event.source :>>',
-        event.source,
-      );
+      // console.log('contentScript window listener ignoring event :>>', event);
       return;
     }
 
     if (event.data.type && event.data.type === 'FROM_PAGE') {
-      console.log(
-        'contentScript window listener parsing eventId :>>',
-        event.data.eventId,
-      );
+      // console.log(
+      //   'contentScript window listener parsing eventId :>>',
+      //   event.data.eventId,
+      // );
 
       const apolloURICacheEvent = {
         message: event.data.text,
@@ -141,6 +138,8 @@ window.addEventListener(
       console.log(
         'contentScript sending Apollo Client to App :>>',
         apolloURICacheEvent,
+        'for eventId :>>',
+        event.data.eventId,
       );
 
       // send the apolloclient URI and cache to the App

--- a/src/extension/contentScript.ts
+++ b/src/extension/contentScript.ts
@@ -153,7 +153,11 @@ const apolloHook = (window: any) => {
             queryManager,
             eventId,
           };
-          window.postMessage(apolloClient);
+
+          // Only send if we have the v3 counters
+          if (apolloClient.queryManager.requestIdCounter !== undefined) {
+            window.postMessage(apolloClient);
+          }
         },
       );
     }

--- a/src/extension/contentScript.ts
+++ b/src/extension/contentScript.ts
@@ -54,10 +54,16 @@ function detectApolloClient(
       const apolloURICacheEvent = {
         eventId,
         event,
-        type: 'FROM_PAGE',
+        type: 'URI_CACHE',
         text: 'Apollo Client URI',
         apolloURI,
         apolloCache: apolloClientHook.Apollo11Client.cache.data.data,
+        queryIdCounter:
+          apolloClientHook.Apollo11Client.queryManager.queryIdCounter,
+        mutationIdCounter:
+          apolloClientHook.Apollo11Client.queryManager.mutationIdCounter,
+        requestIdCounter:
+          apolloClientHook.Apollo11Client.queryManager.requestIdCounter,
       };
 
       // console.log(
@@ -92,6 +98,78 @@ const injectScript = (eventId: any = null, event: any = null) => {
   }
 };
 
+const apolloHook = (window: any) => {
+  let detectionInterval: NodeJS.Timeout;
+
+  const findApolloClient = () => {
+    if (window.__APOLLO_CLIENT__) {
+      clearInterval(detectionInterval);
+
+      console.log(
+        'contentScript injected hook found client',
+        window.__APOLLO_CLIENT__,
+      );
+
+      window.__APOLLO_CLIENT__.__actionHookForDevTools(
+        ({
+          action,
+          state: {queries, mutations},
+          dataWithOptimisticResults: inspector,
+        }) => {
+          const apolloCache = window.__APOLLO_CLIENT__.cache;
+          const apolloQM = window.__APOLLO_CLIENT__.queryManager;
+          let cache: any = {};
+          const queryManager: any = {};
+          if (apolloCache && apolloCache.data && apolloCache.data.data) {
+            cache = apolloCache.data.data;
+          }
+          if (apolloQM) {
+            const store: any = {};
+            apolloQM.queries.forEach((info: any, queryId: any) => {
+              store[queryId] = {
+                variables: info.variables,
+                networkStatus: info.networkStatus,
+                networkError: info.networkError,
+                graphQLErrors: info.graphQLErrors,
+                document: info.document,
+                diff: info.diff,
+              };
+            });
+            queryManager.mutationIdCounter = apolloQM.mutationIdCounter;
+            queryManager.mutationStore = apolloQM.mutationStore;
+            queryManager.queriesStore = store;
+            queryManager.queryIdCounter = apolloQM.queryIdCounter;
+            queryManager.requestIdCounter = apolloQM.requestIdCounter;
+          }
+          const eventId = new Date().getTime().toString();
+          const apolloClient = {
+            type: 'APOLLO_CLIENT',
+            text: 'Apollo Client',
+            action,
+            queries,
+            mutations,
+            inspector,
+            cache,
+            queryManager,
+            eventId,
+          };
+          window.postMessage(apolloClient);
+        },
+      );
+    }
+  };
+  detectionInterval = setInterval(findApolloClient, 1000);
+};
+
+const injectHook = () => {
+  if (document instanceof HTMLDocument) {
+    const script = document.createElement('script');
+    script.textContent = `;(${apolloHook.toString()})(window)`;
+    document.documentElement.appendChild(script);
+    script.parentNode.removeChild(script);
+  }
+};
+
 // Listen for messages from the App
 // If a message to get the cache is received, it will inject the detection code
 chrome.runtime.onMessage.addListener((request, sender) => {
@@ -121,22 +199,26 @@ window.addEventListener(
       return;
     }
 
-    if (event.data.type && event.data.type === 'FROM_PAGE') {
+    if (event.data.type && event.data.type === 'URI_CACHE') {
       // console.log(
       //   'contentScript window listener parsing eventId :>>',
       //   event.data.eventId,
       // );
 
       const apolloURICacheEvent = {
+        type: event.data.type,
         message: event.data.text,
         apolloURI: event.data.apolloURI,
         apolloCache: event.data.apolloCache,
         eventId: event.data.eventId,
         event: event.data.event,
+        queryIdCounter: event.data.queryIdCounter,
+        mutationIdCounter: event.data.mutationIdCounter,
+        requestIdCounter: event.data.requestIdCounter,
       };
 
       console.log(
-        'contentScript sending Apollo Client to App :>>',
+        'contentScript sending Apollo URI & cache to App :>>',
         apolloURICacheEvent,
         'for eventId :>>',
         event.data.eventId,
@@ -149,10 +231,36 @@ window.addEventListener(
           response,
         );
       });
+    } else if (event.data.type && event.data.type === 'APOLLO_CLIENT') {
+      const apolloClient = {
+        action: event.data.action,
+        queries: event.data.queries,
+        mutations: event.data.mutations,
+        inspector: event.data.inspector,
+        type: event.data.type,
+        message: event.data.text,
+        cache: event.data.cache,
+        queryManager: event.data.queryManager,
+        eventId: event.data.eventId,
+      };
+
+      console.log(
+        'contentScript sending Apollo Client to App :>>',
+        apolloClient,
+      );
+
+      chrome.runtime.sendMessage(apolloClient, response => {
+        console.log(
+          'contentScript sendMessage got back response :>>',
+          response,
+        );
+      });
     }
   },
   false,
 );
+
+injectHook();
 
 // Immediately inject the detection code once the contentScript is loaded every time
 // we navigate to a new website

--- a/src/extension/contentScript.ts
+++ b/src/extension/contentScript.ts
@@ -116,10 +116,10 @@ const apolloHook = (window: any) => {
           state: {queries, mutations},
           dataWithOptimisticResults: inspector,
         }) => {
-          console.log(
-            'INJECTED HOOK window.__APOLLO_CLIENT__ :>> ',
-            window.__APOLLO_CLIENT__,
-          );
+          // console.log(
+          //   'INJECTED HOOK window.__APOLLO_CLIENT__ :>> ',
+          //   window.__APOLLO_CLIENT__,
+          // );
           const apolloCache = window.__APOLLO_CLIENT__.cache;
           const apolloQM = window.__APOLLO_CLIENT__.queryManager;
           let cache: any = {};


### PR DESCRIPTION
**Feature**
Detect GraphQL operations

**Description**
This PR changes how we detect GraphQL operations.  Previously, we relied on network events but this left a gap in detection of operations that did not go across the network.  We will now use the `actionHookForDevTools` function to inject our callback.  This hook will invoke our callback every time the Apollo Client makes a query or mutation, even if is done locally and not across the network.  When invoked, the callback will grab the necessary Apollo Client data and send it our app for processing in the Event Log.

There are several key things to note here:
- There are three counters in v3 of the Apollo Client `queryManager`:  `requestIdCounter`, `queryIdCounter`, `mutationIdCounter`.  We rely on these counters to know which operation was just made, so that we know whether to inspect the `queriesStore` or the `mutationStore` to get the actual GraphQL operation data (`operationName`, `query` or `mutation`, `variables`, etc).
- The callback is fired even when there is no new operation, but when the "state" of the operation has changed from `loading` to `complete`.  This will signal when to get the cache and update the Event Log appropriately.  We use a `lastEventId` property to record the last operation that just occurred, so that we can update the cache for that event again.
- We now store the network-based operations into its own Network Events log.  This Network Events log also no longer needs the cache so it no longer sends a message to the `contentScript` to get it.
- There isn't any protection to ensure that our callback is not overwritten by another extension (e.g. Apollo Dev Tools).  Some work will need to be done to ensure that we re-inject our callback as needed.

- There is only one counter in v2 of the Apollo Client:  `idCounter`.  Currently we don't have any way of inspecting which operation just occurred, so for the time being these events are ignored (i.e. no v2 support).  This is done because of the way we render the Event Log:  a chronological timeline of GraphQL operations.  
- We could add support for v2 if we split the Event Log between queries and mutations, which is what the Apollo Dev Tools does, since there is no mixing of operations and it simply displays the content of their respective stores.

**How to test**
- Load the extension and navigate to a test website that has a mix of local vs network events for GraphQL operations
- Observe that the Event Log is populated with entries even when there are no GraphQL network events
- Observe that the Network Log is populated with only network-based GraphQL events

