### PR TITLE
GraphQL operations now update Stores object instead of Event Log directly

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -8,13 +8,14 @@ const App = () => {
   const [apolloURI, setApolloURI] = useState('');
   const [networkURI, setNetworkURI] = useState('');
   const [events, setEvents] = useState({});
+  const [stores, setStores] = useState({});
   const [networkEvents, setNetworkEvents] = useState({});
 
   // Only create the listener when the App is initially mounted
   useEffect(() => {
     // Event listener to obtain the GraphQL server endpoint (URI)
     // and the cache from the Apollo Client
-    createURICacheEventListener(setApolloURI, setEvents);
+    createURICacheEventListener(setApolloURI, setStores);
 
     // Initial load of the App, so send a message to the contentScript to get the cache
     getApolloClient();
@@ -22,6 +23,12 @@ const App = () => {
     // Listen for network events
     createNetworkEventListener(setNetworkURI, setNetworkEvents);
   }, []);
+
+  useEffect(() => {
+    console.log('Current stores :>> ', stores);
+    // do something with the stores
+    // ie update the actual Event Log
+  }, [stores]);
 
   useEffect(() => {
     console.log('Current Event Log :>>', events);

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -6,7 +6,7 @@ import React from 'react';
 // - Apollo Client cache
 export default function createURICacheEventListener(
   setApolloURI: React.Dispatch<React.SetStateAction<string>>,
-  setEvents: React.Dispatch<React.SetStateAction<{}>>,
+  setStores: React.Dispatch<React.SetStateAction<{}>>,
 ) {
   chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     const {tabId} = chrome.devtools.inspectedWindow;
@@ -41,7 +41,7 @@ export default function createURICacheEventListener(
 
       setApolloURI(request.apolloURI);
 
-      setEvents((prevEvents: any) => {
+      setStores((prevEvents: any) => {
         const newEvents = {...prevEvents};
         let {eventId} = request;
         const {event} = request;
@@ -90,97 +90,18 @@ export default function createURICacheEventListener(
 
       console.log('App got client data :>> ', request);
 
-      setEvents((prevEvents: any) => {
+      setStores((prevEvents: any) => {
         const newEvents = {...prevEvents};
-        const {queryManager} = request;
+        const {
+          queryManager,
+          action,
+          queries,
+          mutations,
+          inspector,
+          eventId,
+        } = request;
 
         const event: any = {};
-        event.request = {};
-        event.response = {};
-
-        // console.log(
-        //   'queryManager.requestIdCounter :>> ',
-        //   queryManager.requestIdCounter,
-        // );
-
-        const counterIncremented =
-          queryManager.queryIdCounter > prevEvents.queryIdCounter ||
-          queryManager.mutationIdCounter > prevEvents.mutationIdCounter;
-
-        // Check if this event is a new query
-        if (queryManager.queryIdCounter > prevEvents.queryIdCounter) {
-          // console.log(
-          //   'queryManager.queryIdCounter :>> ',
-          //   queryManager.queryIdCounter,
-          // );
-          // console.log(
-          //   'queryManager.queriesStore :>> ',
-          //   queryManager.queriesStore,
-          // );
-
-          event.request.operation = {
-            operationName:
-              queryManager.queriesStore[queryManager.queryIdCounter - 1]
-                .document.definitions[0].name.value,
-            query:
-              queryManager.queriesStore[queryManager.queryIdCounter - 1]
-                .document.loc.source.body,
-          };
-          event.response.content = 'query';
-        } else if (
-          queryManager.mutationIdCounter > prevEvents.mutationIdCounter
-        ) {
-          // Check if event is a new mutation
-          // console.log(
-          //   'queryManager.mutationIdCounter :>> ',
-          //   queryManager.mutationIdCounter,
-          // );
-          // console.log(
-          //   'queryManager.mutationStore :>> ',
-          //   queryManager.mutationStore,
-          // );
-
-          event.request.operation = {
-            operationName:
-              queryManager.mutationStore[queryManager.mutationIdCounter - 1]
-                .mutation.definitions[0].name.value,
-            query:
-              queryManager.mutationStore[queryManager.mutationIdCounter - 1]
-                .mutation.loc.source.body,
-          };
-          event.response.content = 'mutation';
-        } else {
-          // Query / Mutation counters didn't increase, so just update the cache
-          // for the most recent eventId
-          // console.log(
-          //   'Query / Mutation counters have not increased :>> ',
-          //   queryManager.queryIdCounter,
-          //   prevEvents.queryIdCounter,
-          //   queryManager.mutationIdCounter,
-          //   prevEvents.mutationIdCounter,
-          //   queryManager.requestIdCounter,
-          //   prevEvents.requestIdCounter,
-          // );
-        }
-
-        let eventId;
-        if (counterIncremented) {
-          eventId = request.eventId;
-        } else {
-          // console.log('prevEvents.lastEventId :>> ', prevEvents.lastEventId);
-          eventId = prevEvents.lastEventId;
-          // console.log(
-          //   'Counters did not increase, re-using eventId :>> ',
-          //   eventId,
-          // );
-          event.request.operation = prevEvents[eventId].request.operation;
-          event.response.content = prevEvents[eventId].response.content;
-        }
-
-        if (eventId === 'null' || eventId === undefined) {
-          // console.log('eventId is null, setting to 0');
-          eventId = '0';
-        }
 
         if (!newEvents[eventId]) {
           // console.log('newEvents does not have eventId :>> ', eventId);
@@ -192,13 +113,13 @@ export default function createURICacheEventListener(
         newEvents[eventId] = {...prevEvents[eventId], ...event};
         newEvents[eventId].cache = request.cache;
 
-        // Update all of the counters
-        newEvents.requestIdCounter = queryManager.requestIdCounter;
-        newEvents.queryIdCounter = queryManager.queryIdCounter;
-        newEvents.mutationIdCounter = queryManager.mutationIdCounter;
-        newEvents.lastEventId = eventId;
+        newEvents[eventId].action = action;
+        newEvents[eventId].queries = queries;
+        newEvents[eventId].mutations = mutations;
+        newEvents[eventId].inspector = inspector;
+        newEvents[eventId].queryManager = queryManager;
 
-        // console.log('newEvents :>> ', newEvents);
+        console.log('newEvents :>> ', newEvents);
 
         return newEvents;
       });

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -142,13 +142,11 @@ export default function createURICacheEventListener(
 
           event.request.operation = {
             operationName:
-              queryManager.mutationStore.store[
-                queryManager.mutationIdCounter - 1
-              ].mutation.definitions[0].name.value,
+              queryManager.mutationStore[queryManager.mutationIdCounter - 1]
+                .mutation.definitions[0].name.value,
             query:
-              queryManager.mutationStore.store[
-                queryManager.mutationIdCounter - 1
-              ].mutation.loc.source.body,
+              queryManager.mutationStore[queryManager.mutationIdCounter - 1]
+                .mutation.loc.source.body,
           };
           event.response.content = 'mutation';
         } else {

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -169,7 +169,7 @@ export default function createURICacheEventListener(
         if (counterIncremented) {
           eventId = request.eventId;
         } else {
-          console.log('prevEvents.lastEventId :>> ', prevEvents.lastEventId);
+          // console.log('prevEvents.lastEventId :>> ', prevEvents.lastEventId);
           eventId = prevEvents.lastEventId;
           // console.log(
           //   'Counters did not increase, re-using eventId :>> ',

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -64,9 +64,9 @@ export default function createURICacheEventListener(
 
         newEvents[eventId] = {...prevEvents[eventId], ...event};
         newEvents[eventId].cache = request.apolloCache;
-        newEvents.queryIdCounter = request.queryIdCounter;
-        newEvents.mutationIdCounter = request.mutationIdCounter;
-        newEvents.requestIdCounter = request.requestIdCounter;
+        // newEvents.queryIdCounter = request.queryIdCounter;
+        // newEvents.mutationIdCounter = request.mutationIdCounter;
+        // newEvents.requestIdCounter = request.requestIdCounter;
         newEvents.lastEventId = eventId;
 
         console.log(
@@ -88,7 +88,7 @@ export default function createURICacheEventListener(
       //   return;
       // }
 
-      console.log('App got client data :>> ', request);
+      // console.log('App got client data :>> ', request);
 
       setStores((prevEvents: any) => {
         const newEvents = {...prevEvents};
@@ -118,8 +118,9 @@ export default function createURICacheEventListener(
         newEvents[eventId].mutations = mutations;
         newEvents[eventId].inspector = inspector;
         newEvents[eventId].queryManager = queryManager;
+        newEvents.lastEventId = eventId;
 
-        console.log('newEvents :>> ', newEvents);
+        // console.log('newEvents :>> ', newEvents);
 
         return newEvents;
       });

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -169,6 +169,7 @@ export default function createURICacheEventListener(
         if (counterIncremented) {
           eventId = request.eventId;
         } else {
+          console.log('prevEvents.lastEventId :>> ', prevEvents.lastEventId);
           eventId = prevEvents.lastEventId;
           // console.log(
           //   'Counters did not increase, re-using eventId :>> ',

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -211,7 +211,7 @@ export default function createURICacheEventListener(
 // Send a message to the contentScript to get the Apollo Client cache
 // Need to pass it the pre-generated eventId so it can correlate the cache + data
 // with its corresponding network request
-export function getApolloClient(eventId: string = 'null', event: any = null) {
+export function getApolloClient() {
   // Get the active tab and send a message to the contentScript to get the cache
   chrome.tabs.query({active: true}, function getClientData(tabs) {
     if (tabs.length) {
@@ -225,8 +225,6 @@ export function getApolloClient(eventId: string = 'null', event: any = null) {
 
       chrome.tabs.sendMessage(tabs[0].id, {
         type: 'GET_CACHE',
-        eventId,
-        event,
       });
     }
   });

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -83,10 +83,10 @@ export default function createURICacheEventListener(
       // v3 has requestIdCounter, queryIdCounter, mutationIdCounter
       // Bail out if we don't see the v3 counters for now
       // TODO: support v2 clients
-      if (request.queryManager.requestIdCounter === undefined) {
-        console.log('App ignoring v2 data', request);
-        return;
-      }
+      // if (request.queryManager.requestIdCounter === undefined) {
+      //   console.log('App ignoring v2 data', request);
+      //   return;
+      // }
 
       console.log('App got client data :>> ', request);
 

--- a/src/extension/contentScript.ts
+++ b/src/extension/contentScript.ts
@@ -87,14 +87,18 @@ function detectApolloClient(
 // This will allow us to obtain the __APOLLO_CLIENT__ object
 // on the application's window object.
 // https://stackoverflow.com/questions/12395722/can-the-window-object-be-modified-from-a-chrome-extension
-const injectScript = (eventId: any = null, event: any = null) => {
+const injectScript = () => {
+  // if (document instanceof HTMLDocument) {
+  //   const script = document.createElement('script');
+  //   script.textContent = `;(${detectApolloClient.toString()})(window)`;
+  //   document.documentElement.appendChild(script);
+  //   script.parentNode.removeChild(script);
+  // }
   if (document instanceof HTMLDocument) {
-    const script = document.createElement('script');
-    script.textContent = `;(${detectApolloClient.toString()})(window, '${eventId}', ${JSON.stringify(
-      event,
-    )})`;
-    document.documentElement.appendChild(script);
-    script.parentNode.removeChild(script);
+    const s = document.createElement('script');
+    s.setAttribute('data-version', chrome.runtime.getManifest().version);
+    s.src = chrome.extension.getURL('bundles/apollo.bundle.js');
+    document.body.appendChild(s);
   }
 };
 
@@ -109,7 +113,7 @@ chrome.runtime.onMessage.addListener((request, sender) => {
   );
 
   if (request && request.type && request.type === 'GET_CACHE') {
-    injectScript(request.eventId, request.event);
+    injectScript();
   }
 });
 

--- a/src/extension/contentScript.ts
+++ b/src/extension/contentScript.ts
@@ -119,7 +119,7 @@ chrome.runtime.onMessage.addListener((request, sender) => {
 window.addEventListener(
   'message',
   function sendClientData(event) {
-    // console.log('contentScript window listener got event.data :>>', event.data);
+    console.log('contentScript window listener got event.data :>>', event.data);
 
     // We only accept messages from ourselves
     if (event.source !== window) {
@@ -137,7 +137,7 @@ window.addEventListener(
         type: event.data.type,
         message: event.data.text,
         apolloURI: event.data.apolloURI,
-        apolloCache: event.data.apolloCache,
+        apolloCache: JSON.parse(event.data.apolloCache),
         eventId: event.data.eventId,
         event: event.data.event,
         queryIdCounter: event.data.queryIdCounter,
@@ -167,7 +167,7 @@ window.addEventListener(
         inspector: event.data.inspector,
         type: event.data.type,
         message: event.data.text,
-        cache: event.data.cache,
+        cache: JSON.parse(event.data.cache),
         queryManager: event.data.queryManager,
         eventId: event.data.eventId,
       };

--- a/src/extension/contentScript.ts
+++ b/src/extension/contentScript.ts
@@ -137,7 +137,7 @@ window.addEventListener(
         type: event.data.type,
         message: event.data.text,
         apolloURI: event.data.apolloURI,
-        apolloCache: JSON.parse(event.data.apolloCache),
+        apolloCache: event.data.apolloCache,
         eventId: event.data.eventId,
         event: event.data.event,
         queryIdCounter: event.data.queryIdCounter,
@@ -167,7 +167,7 @@ window.addEventListener(
         inspector: event.data.inspector,
         type: event.data.type,
         message: event.data.text,
-        cache: JSON.parse(event.data.cache),
+        cache: event.data.cache,
         queryManager: event.data.queryManager,
         eventId: event.data.eventId,
       };

--- a/src/extension/contentScript.ts
+++ b/src/extension/contentScript.ts
@@ -1,99 +1,10 @@
 console.log('Executing contentScript.ts...');
 
-interface IApolloClientHook {
-  Apollo11Client: any;
-}
-
-// This code will be injected into the DOM of the website
-// It will set up an interval timer to try and detect the Apollo Client object
-// every 1000ms.  Once it finds it, the interval timer will be cleared
-//
-// The eventId will be null if this is very first time we are injecting this script
-// Otherwise, it will contain the pre-generated unix Epoch time of a GraphQL network event
-function detectApolloClient(
-  window: any,
-  eventId: string = null,
-  event: any = null,
-) {
-  const apolloClientHook: IApolloClientHook = {
-    Apollo11Client: null,
-  };
-
-  // console.log('Detect Apollo Client with :: ', eventId);
-
-  // Need to add this eslint global to mitigate the following error:
-  //   22:26  error    'NodeJS' is not defined       no-undef
-  /* global NodeJS */
-  let detectionInterval: NodeJS.Timeout;
-
-  // Helper function to actually detect the Apollo Client
-  // This function will be executed by the interval timer
-  function findApolloClient() {
-    if (window.__APOLLO_CLIENT__) {
-      apolloClientHook.Apollo11Client = window.__APOLLO_CLIENT__;
-      clearInterval(detectionInterval);
-
-      console.log(
-        'contentScript findApolloClient found :>>',
-        apolloClientHook.Apollo11Client,
-      );
-
-      let apolloURI = '';
-      // Check if the uri exists on the client object
-      if (
-        apolloClientHook.Apollo11Client.link &&
-        apolloClientHook.Apollo11Client.link.options &&
-        apolloClientHook.Apollo11Client.link.options.uri
-      ) {
-        apolloURI = apolloClientHook.Apollo11Client.link.options.uri;
-        // console.log('contentScript findClient - URI exists :>>', apolloURI);
-      }
-
-      // console.log('findApolloClient event', event);
-      // console.log('findApolloClient json event', JSON.parse(event));
-      const apolloURICacheEvent = {
-        eventId,
-        event,
-        type: 'URI_CACHE',
-        text: 'Apollo Client URI',
-        apolloURI,
-        apolloCache: apolloClientHook.Apollo11Client.cache.data.data,
-        queryIdCounter:
-          apolloClientHook.Apollo11Client.queryManager.queryIdCounter,
-        mutationIdCounter:
-          apolloClientHook.Apollo11Client.queryManager.mutationIdCounter,
-        requestIdCounter:
-          apolloClientHook.Apollo11Client.queryManager.requestIdCounter,
-      };
-
-      // console.log(
-      //   'contentScript findClient - posting message :>>',
-      //   apolloURICacheEvent,
-      // );
-
-      // Send a message from the injected script to the contentScript
-      // with the Apollo Client URI and the Apollo Client cache
-      window.postMessage(apolloURICacheEvent, '*');
-    }
-  }
-
-  // TODO: We are only clearing the timer if the Apollo client is found, otherwise it will
-  // keep running indefinitely.  We should consider stopping it after some extended period
-  // of time, such as 10 minutes?  The original Apollo client code stopped after 10 seconds.
-  detectionInterval = setInterval(findApolloClient, 1000);
-}
-
 // Need to inject our script as an IIFE into the DOM
 // This will allow us to obtain the __APOLLO_CLIENT__ object
 // on the application's window object.
 // https://stackoverflow.com/questions/12395722/can-the-window-object-be-modified-from-a-chrome-extension
 const injectScript = () => {
-  // if (document instanceof HTMLDocument) {
-  //   const script = document.createElement('script');
-  //   script.textContent = `;(${detectApolloClient.toString()})(window)`;
-  //   document.documentElement.appendChild(script);
-  //   script.parentNode.removeChild(script);
-  // }
   if (document instanceof HTMLDocument) {
     const s = document.createElement('script');
     s.setAttribute('data-version', chrome.runtime.getManifest().version);
@@ -192,16 +103,9 @@ window.addEventListener(
   false,
 );
 
-if (document instanceof HTMLDocument) {
-  const s = document.createElement('script');
-  s.setAttribute('data-version', chrome.runtime.getManifest().version);
-  s.src = chrome.extension.getURL('bundles/apollo.bundle.js');
-  document.body.appendChild(s);
-}
-
 // Immediately inject the detection code once the contentScript is loaded every time
 // we navigate to a new website
 // This mitigates issues where the App panel has already mounted and sent its initial
 // requests for the URI and cache, but there isn't any website loaded yet (i.e. empty tab)
 
-// injectScript();
+injectScript();

--- a/src/hook/apollo.ts
+++ b/src/hook/apollo.ts
@@ -1,5 +1,101 @@
 // import onChange from '../watch';
 
+function apollo11Callback(
+  win: any,
+  action: any,
+  queries: any,
+  mutations: any,
+  inspector: any,
+  initial: boolean = false,
+) {
+  console.log(
+    'apollo11Callback win.__APOLLO_CLIENT__ :>> ',
+    win.__APOLLO_CLIENT__,
+  );
+  console.log(
+    'win.__APOLLO_CLIENT__.cache.data.data :>> ',
+    win.__APOLLO_CLIENT__.cache.data.data,
+  );
+  const extract1 = win.__APOLLO_CLIENT__.cache.extract(true);
+  console.log('extract1 :>> ', extract1);
+  const extract2 = win.__APOLLO_CLIENT__.cache.extract(false);
+  console.log('extract2 :>> ', extract2);
+  const tempCache = win.__APOLLO_CLIENT__.cache.data.data;
+  console.log('tempCache :>> ', tempCache);
+  const strCache = JSON.stringify(tempCache);
+  console.log('c.d.d', JSON.stringify(win.__APOLLO_CLIENT__.cache.data.data));
+  console.log('strCache :>> ', strCache);
+
+  const {link} = win.__APOLLO_CLIENT__;
+  let apolloURI = '';
+
+  const apolloCache = win.__APOLLO_CLIENT__.cache;
+  const apolloQM = win.__APOLLO_CLIENT__.queryManager;
+  let cache: any = {};
+  const queryManager: any = {};
+  if (apolloCache && apolloCache.data && apolloCache.data.data) {
+    cache = apolloCache.data.data;
+  }
+  if (apolloQM) {
+    const store: any = {};
+    if (apolloQM.queries instanceof Map) {
+      apolloQM.queries.forEach((info: any, queryId: any) => {
+        store[queryId] = {
+          variables: info.variables,
+          networkStatus: info.networkStatus,
+          networkError: info.networkError,
+          graphQLErrors: info.graphQLErrors,
+          document: info.document,
+          diff: info.diff,
+        };
+      });
+    } else {
+      console.log('apolloQM.queries is not a Map :>> ', apolloQM.queries);
+    }
+    queryManager.queriesStore = store;
+    queryManager.mutationStore = apolloQM.mutationStore;
+
+    // v3 counters
+    queryManager.requestIdCounter = apolloQM.requestIdCounter;
+    queryManager.queryIdCounter = apolloQM.queryIdCounter;
+    queryManager.mutationIdCounter = apolloQM.mutationIdCounter;
+
+    // v2 counter
+    queryManager.idCounter = apolloQM.idCounter;
+  }
+
+  if (link && link.options && link.options.uri) {
+    apolloURI = link.options.uri;
+    // console.log('contentScript findClient - URI exists :>>', apolloURI);
+  }
+
+  const type = initial ? 'URI_CACHE' : 'APOLLO_CLIENT';
+
+  const eventId = initial ? '0' : new Date().getTime().toString();
+  const apolloClient = {
+    type,
+    text: 'Apollo Client',
+    action,
+    queries,
+    mutations,
+    inspector,
+    cache: JSON.stringify(cache),
+    apolloCache: JSON.stringify(cache),
+    queryManager,
+    eventId,
+    apolloURI,
+    requestIdCounter: queryManager.requestIdCounter,
+    queryIdCounter: queryManager.queryIdCounter,
+    mutationIdCounter: queryManager.mutationIdCounter,
+  };
+
+  console.log(
+    'apollo11Callback sending apolloClient to contentScript :>> ',
+    apolloClient,
+  );
+  win.postMessage(apolloClient);
+}
+
 (function hooked(win: any) {
   // function updateMutationStore() {
   //   console.log('there will be need to catalogue ');
@@ -8,7 +104,13 @@
   let detectionInterval: NodeJS.Timeout;
 
   const findApolloClient = () => {
-    if (win.__APOLLO_CLIENT__) {
+    if (
+      win.__APOLLO_CLIENT__ &&
+      win.__APOLLO_CLIENT__.cache &&
+      win.__APOLLO_CLIENT__.cache.data &&
+      win.__APOLLO_CLIENT__.cache.data.data &&
+      Object.entries(win.__APOLLO_CLIENT__.cache.data.data).length > 0
+    ) {
       clearInterval(detectionInterval);
 
       console.log(
@@ -16,6 +118,12 @@
         win.__APOLLO_CLIENT__,
       );
 
+      apollo11Callback(win, null, null, null, null, true);
+
+      // send the first message manually
+      // grab all the client data
+      // send first postMessage
+      // --> manually invoked our callback
       win.__APOLLO_CLIENT__.__actionHookForDevTools(
         ({
           action,
@@ -26,57 +134,7 @@
             'INJECTED HOOK @ MODULE window.__APOLLO_CLIENT__ :>> ',
             win.__APOLLO_CLIENT__,
           );
-          const apolloCache = win.__APOLLO_CLIENT__.cache;
-          const apolloQM = win.__APOLLO_CLIENT__.queryManager;
-          let cache: any = {};
-          const queryManager: any = {};
-          if (apolloCache && apolloCache.data && apolloCache.data.data) {
-            cache = apolloCache.data.data;
-          }
-          if (apolloQM) {
-            const store: any = {};
-            if (apolloQM.queries instanceof Map) {
-              apolloQM.queries.forEach((info: any, queryId: any) => {
-                store[queryId] = {
-                  variables: info.variables,
-                  networkStatus: info.networkStatus,
-                  networkError: info.networkError,
-                  graphQLErrors: info.graphQLErrors,
-                  document: info.document,
-                  diff: info.diff,
-                };
-              });
-            } else {
-              console.log(
-                'apolloQM.queries is not a Map :>> ',
-                apolloQM.queries,
-              );
-            }
-            queryManager.queriesStore = store;
-            queryManager.mutationStore = apolloQM.mutationStore;
-
-            // v3 counters
-            queryManager.requestIdCounter = apolloQM.requestIdCounter;
-            queryManager.queryIdCounter = apolloQM.queryIdCounter;
-            queryManager.mutationIdCounter = apolloQM.mutationIdCounter;
-
-            // v2 counter
-            queryManager.idCounter = apolloQM.idCounter;
-          }
-          const eventId = new Date().getTime().toString();
-          const apolloClient = {
-            type: 'APOLLO_CLIENT',
-            text: 'Apollo Client',
-            action,
-            queries,
-            mutations,
-            inspector,
-            cache,
-            queryManager,
-            eventId,
-          };
-
-          win.postMessage(apolloClient);
+          apollo11Callback(win, action, queries, mutations, inspector);
         },
       );
 

--- a/src/hook/apollo.ts
+++ b/src/hook/apollo.ts
@@ -1,5 +1,3 @@
-// import onChange from '../watch';
-
 function apollo11Callback(
   win: any,
   action: any,
@@ -8,23 +6,10 @@ function apollo11Callback(
   inspector: any,
   initial: boolean = false,
 ) {
-  console.log(
-    'apollo11Callback win.__APOLLO_CLIENT__ :>> ',
-    win.__APOLLO_CLIENT__,
-  );
-  console.log(
-    'win.__APOLLO_CLIENT__.cache.data.data :>> ',
-    win.__APOLLO_CLIENT__.cache.data.data,
-  );
-  const extract1 = win.__APOLLO_CLIENT__.cache.extract(true);
-  console.log('extract1 :>> ', extract1);
-  const extract2 = win.__APOLLO_CLIENT__.cache.extract(false);
-  console.log('extract2 :>> ', extract2);
-  const tempCache = win.__APOLLO_CLIENT__.cache.data.data;
-  console.log('tempCache :>> ', tempCache);
-  const strCache = JSON.stringify(tempCache);
-  console.log('c.d.d', JSON.stringify(win.__APOLLO_CLIENT__.cache.data.data));
-  console.log('strCache :>> ', strCache);
+  // console.log(
+  //   'apollo11Callback win.__APOLLO_CLIENT__ :>> ',
+  //   win.__APOLLO_CLIENT__,
+  // );
 
   const {link} = win.__APOLLO_CLIENT__;
   let apolloURI = '';
@@ -66,7 +51,6 @@ function apollo11Callback(
 
   if (link && link.options && link.options.uri) {
     apolloURI = link.options.uri;
-    // console.log('contentScript findClient - URI exists :>>', apolloURI);
   }
 
   const type = initial ? 'URI_CACHE' : 'APOLLO_CLIENT';
@@ -79,8 +63,8 @@ function apollo11Callback(
     queries,
     mutations,
     inspector,
-    cache: JSON.stringify(cache),
-    apolloCache: JSON.stringify(cache),
+    cache,
+    apolloCache: cache,
     queryManager,
     eventId,
     apolloURI,
@@ -89,17 +73,14 @@ function apollo11Callback(
     mutationIdCounter: queryManager.mutationIdCounter,
   };
 
-  console.log(
-    'apollo11Callback sending apolloClient to contentScript :>> ',
-    apolloClient,
-  );
+  // console.log(
+  //   'apollo11Callback sending apolloClient to contentScript :>> ',
+  //   apolloClient,
+  // );
   win.postMessage(apolloClient);
 }
 
 (function hooked(win: any) {
-  // function updateMutationStore() {
-  //   console.log('there will be need to catalogue ');
-  // }
   // eslint-disable-next-line no-undef
   let detectionInterval: NodeJS.Timeout;
 
@@ -113,36 +94,26 @@ function apollo11Callback(
     ) {
       clearInterval(detectionInterval);
 
-      console.log(
-        'contentScript injected hook found client',
-        win.__APOLLO_CLIENT__,
-      );
+      // console.log(
+      //   'contentScript injected hook found client',
+      //   win.__APOLLO_CLIENT__,
+      // );
 
       apollo11Callback(win, null, null, null, null, true);
 
-      // send the first message manually
-      // grab all the client data
-      // send first postMessage
-      // --> manually invoked our callback
       win.__APOLLO_CLIENT__.__actionHookForDevTools(
         ({
           action,
           state: {queries, mutations},
           dataWithOptimisticResults: inspector,
         }) => {
-          console.log(
-            'INJECTED HOOK @ MODULE window.__APOLLO_CLIENT__ :>> ',
-            win.__APOLLO_CLIENT__,
-          );
+          // console.log(
+          //   'INJECTED HOOK @ MODULE window.__APOLLO_CLIENT__ :>> ',
+          //   win.__APOLLO_CLIENT__,
+          // );
           apollo11Callback(win, action, queries, mutations, inspector);
         },
       );
-
-      // // eslint-disable-next-line no-param-reassign
-      // win.__APOLLO_CLIENT__.queryManager.mutationStore.store = onChange(
-      //   win.__APOLLO_CLIENT__.queryManager.mutationStore.store,
-      //   () => updateMutationStore(),
-      // );
     }
   };
   detectionInterval = setInterval(findApolloClient, 1000);

--- a/src/hook/apollo.ts
+++ b/src/hook/apollo.ts
@@ -38,7 +38,7 @@ function apollo11Callback(
       console.log('apolloQM.queries is not a Map :>> ', apolloQM.queries);
     }
     queryManager.queriesStore = store;
-    queryManager.mutationStore = apolloQM.mutationStore;
+    queryManager.mutationStore = apolloQM.mutationStore.store;
 
     // v3 counters
     queryManager.requestIdCounter = apolloQM.requestIdCounter;
@@ -107,10 +107,10 @@ function apollo11Callback(
           state: {queries, mutations},
           dataWithOptimisticResults: inspector,
         }) => {
-          // console.log(
-          //   'INJECTED HOOK @ MODULE window.__APOLLO_CLIENT__ :>> ',
-          //   win.__APOLLO_CLIENT__,
-          // );
+          console.log(
+            'INJECTED HOOK @ MODULE window.__APOLLO_CLIENT__ :>> ',
+            win.__APOLLO_CLIENT__,
+          );
           apollo11Callback(win, action, queries, mutations, inspector);
         },
       );


### PR DESCRIPTION
**Feature**:
Local GraphQL operation detection

**Description**:
This PR now changes how we update the `Event Log` object -- i.e., we now update a separate `Stores` object that maintains a copy of the `queriesStore` and `mutationStore` every time the devtools callback is invoked.

Previously, we directly updated the `Event Log` within the messaging loop and this created some unnecessarily complex logic in the injection scripts as well as the messaging logic.

We decided to separate the parsing out to determine the Events from all of these messages for several reasons.

First, it allows us to keep the detection logic and messaging to only be concerned with those aspects.  Detect an event, send a message with all available data, and let the app later parse it as needed.

Second, it allows us to maintain entire copies of the the respective stores with every local operation and merely pass that along to the app, letting it determine what to discard.  This minimizes rework in the messaging layer later on should we change how we parse the data.
 
Lastly, a side effect of removing this parsing logic (deferring it later) is that we can capture v2 client data without discarding it as we do currently.  Should we want to fully support v2, we can do so at the app / parsing layer rather than the underlying plumbing.

Another change was in refactoring the number of injected scripts.  We've consolidated this into a single function that is immediately invoked when when we also attempt to inject our devtools callback.

We re-use this function in `getApolloClients` to get the initial `cache` and `URI` data, as in some cases devtools callback is not immediately invoked, or when the app panel is mounted after the `contentScript` has already executed.

While we now inject our script at multiple times (`contentScript` initial load, app panel mounted), we still need to do some additional protection in case our devtools callback is overwritten by another extension.

We also fixed how we injected our script such that we now wait for the Apollo Client to be fully instantiated with (cache) data.  This fixed an issue where the very first message sent to the app had an empty cache.

NOTE:
A side effect of this PR is that the Event Log will be empty until we add back that parsing logic.
