### PR TITLE
Managed event log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # apollo11
+
 # hello

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/react-html-parser": "^2.0.1",
     "@types/react-json-tree": "^0.6.11",
     "@types/uuid": "^8.3.0",
+    "@wry/equality": "^0.2.0",
     "babel-eslint": "^10.1.0",
     "clsx": "^1.1.1",
     "codemirror-graphql": "^0.12.1",

--- a/src/app/ApolloTab.tsx
+++ b/src/app/ApolloTab.tsx
@@ -2,10 +2,13 @@ import React, {useState} from 'react';
 import {makeStyles, createStyles, Theme} from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
-import EventLog from './EventLog';
-import EventDetails from './EventDetails';
+
+import {ApolloTabProps} from './utils/managedlog/lib/eventLogData';
 import Cache from './Cache';
 import CacheDetails from './CacheDetails';
+import EventLog from './EventLog';
+import EventDetails from './EventDetails';
+import EventNode from './utils/managedlog/lib/eventLogNode';
 
 // interface Props extends StyledComponentProps<ClassKeyOfStyles<typeof styles>> {
 //   myProp: string;
@@ -35,18 +38,18 @@ const useStyles: any = makeStyles((theme: Theme) =>
   }),
 );
 
-type ApolloTabProps = {
-  eventLog: any;
-};
-
 function ApolloTab({eventLog}: ApolloTabProps) {
   const classes = useStyles();
-  const [cacheDetailsVisible, setCacheDetailsVisible] = useState(false);
-  const [activeEvent, setActiveEvent] = useState('');
-  const [activeCache, setActiveCache] = useState('');
+  const [cacheDetailsVisible, setCacheDetailsVisible] = useState(() => false);
+  const [activeEvent, setActiveEvent] = useState(
+    (): EventNode => {
+      return eventLog.eventHead;
+    },
+  );
+  const [activeCache, setActiveCache] = useState(() => ({}));
 
   // Function to change the active event key to pass active event to components
-  const handleEventChange = (e: any) => {
+  const handleEventChange = (e: EventNode) => {
     setActiveEvent(e);
   };
 
@@ -87,7 +90,7 @@ function ApolloTab({eventLog}: ApolloTabProps) {
           justify="center">
           <Grid item xs={12} className={classes.eventDetails}>
             <Paper className={classes.paper}>
-              <EventDetails activeEvent={activeEvent} eventLog={eventLog} />
+              <EventDetails activeEvent={activeEvent} />
             </Paper>
           </Grid>
 
@@ -97,7 +100,6 @@ function ApolloTab({eventLog}: ApolloTabProps) {
                 <CacheDetails
                   activeCache={activeCache}
                   activeEvent={activeEvent}
-                  eventLog={eventLog}
                 />
               </Paper>
             </Grid>
@@ -109,7 +111,6 @@ function ApolloTab({eventLog}: ApolloTabProps) {
             <Cache
               toggleCacheDetails={handleCacheSelection}
               activeEvent={activeEvent}
-              eventLog={eventLog}
               handleCacheChange={handleCacheChange}
               cacheDetailsVisible={cacheDetailsVisible}
             />

--- a/src/app/Cache.tsx
+++ b/src/app/Cache.tsx
@@ -1,28 +1,24 @@
 import React from 'react';
 
-import ListSubheader from '@material-ui/core/ListSubheader';
+import EventIcon from '@material-ui/icons/Event';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
+// import ListSubheader from '@material-ui/core/ListSubheader';
 
-import EventIcon from '@material-ui/icons/Event';
-
-type CacheProps = {
-  eventLog: any;
-  activeEvent: string;
-  toggleCacheDetails: any;
-  handleCacheChange: any;
-  cacheDetailsVisible: boolean;
-};
+import {CacheProps} from './utils/managedlog/lib/eventLogNode';
 
 const Cache = ({
   activeEvent,
-  eventLog,
   toggleCacheDetails,
   handleCacheChange,
   cacheDetailsVisible,
 }: CacheProps) => {
+  if (activeEvent === null) return <></>;
+  const {
+    content: {event, cache},
+  } = activeEvent;
   let buttonText: string = 'Show Cache Details';
 
   if (cacheDetailsVisible) {
@@ -30,19 +26,16 @@ const Cache = ({
   } else {
     buttonText = 'Show Cache Details';
   }
-
   return (
     <div>
-      <h1>Current Cache</h1>
-      {eventLog[activeEvent] ? (
-        <List
-          component="nav"
-          aria-labelledby="nested-list-subheader"
-          subheader={
+      <h1>Cache</h1>
+      {event ? (
+        <List component="nav" aria-labelledby="nested-list-subheader">
+          {/* subheader={
             <ListSubheader component="div" id="nested-list-subheader">
               Current Cache
             </ListSubheader>
-          }>
+          } */}
           <button
             type="button"
             onClick={() => {
@@ -50,34 +43,35 @@ const Cache = ({
             }}>
             {buttonText}
           </button>
-          {Object.keys(eventLog[activeEvent].cache).map((cacheItem: any) => {
-            const cacheString = cacheItem.toString();
+          {cache &&
+            Object.keys(cache).map((cacheItem: any) => {
+              const cacheString = cacheItem.toString();
 
-            // Check if key is 0 or undefined
-            if (
-              cacheItem === 0 ||
-              cacheItem === undefined ||
-              cacheItem === 'undefined' ||
-              !cacheItem ||
-              cacheItem === '0' ||
-              cacheString === '0'
-            ) {
-              // if key is 0 or undefined, just log it to the console and return so the next lines of code don't run
-              return console.log('CACHE === undefined', cacheItem);
-            }
+              // Check if key is 0 or undefined
+              if (
+                cacheItem === 0 ||
+                cacheItem === undefined ||
+                cacheItem === 'undefined' ||
+                !cacheItem ||
+                cacheItem === '0' ||
+                cacheString === '0'
+              ) {
+                // if key is 0 or undefined, just log it to the console and return so the next lines of code don't run
+                return console.log('CACHE === undefined', cacheItem);
+              }
 
-            return (
-              <ListItem
-                button
-                key={cacheItem}
-                onClick={() => handleCacheChange(cacheItem)}>
-                <ListItemIcon>
-                  <EventIcon />
-                </ListItemIcon>
-                <ListItemText primary={cacheItem} />
-              </ListItem>
-            );
-          })}
+              return (
+                <ListItem
+                  button
+                  key={cacheItem}
+                  onClick={() => handleCacheChange(cacheItem)}>
+                  <ListItemIcon>
+                    <EventIcon />
+                  </ListItemIcon>
+                  <ListItemText primary={cacheItem} />
+                </ListItem>
+              );
+            })}
         </List>
       ) : (
         <div>No event selected</div>

--- a/src/app/CacheDetails.tsx
+++ b/src/app/CacheDetails.tsx
@@ -2,28 +2,20 @@ import React from 'react';
 import ReactJson from 'react-json-view';
 import Typography from '@material-ui/core/Typography';
 
-type CacheDetailsProps = {
-  eventLog: any;
-  activeEvent: string;
-  activeCache: any;
-};
+import {CacheDetailsProps} from './utils/managedlog/lib/eventLogNode';
 
-const CacheDetails = ({
-  activeEvent,
-  activeCache,
-  eventLog,
-}: CacheDetailsProps) => {
+const CacheDetails = ({activeEvent, activeCache}: CacheDetailsProps) => {
+  if (activeEvent === null) return <></>;
+  const {
+    content: {event, cache},
+  } = activeEvent;
   return (
     <div>
       <h1>Cache Details</h1>
-
-      {eventLog[activeEvent] ? (
+      {event ? (
         <div>
           <Typography align="left">
-            <ReactJson
-              name={false}
-              src={eventLog[activeEvent].cache[activeCache]}
-            />
+            <ReactJson name={false} src={cache[activeCache]} />
           </Typography>
         </div>
       ) : (

--- a/src/app/EventDetails.tsx
+++ b/src/app/EventDetails.tsx
@@ -2,31 +2,28 @@ import React from 'react';
 import ReactJson from 'react-json-view';
 import Typography from '@material-ui/core/Typography';
 
-type EventDetailsProps = {
-  eventLog: any;
-  activeEvent: string;
-};
+import {EventDetailsProps} from './utils/managedlog/lib/eventLogNode';
 
-const EventDetails = ({activeEvent, eventLog}: EventDetailsProps) => {
+const EventDetails = ({activeEvent}: EventDetailsProps) => {
+  if (activeEvent === null) return <></>;
+  const {
+    content: {event},
+  } = activeEvent; // eventId
   return (
     <div>
       <h1>Event Details</h1>
-      <h2>{activeEvent}</h2>
-      {eventLog[activeEvent] ? (
+      {/* <h2>{eventId}</h2> */}
+      {event ? (
         <div>
           <Typography align="left">
             <h3>Operation</h3>
             <ReactJson
               name="operation"
-              src={eventLog[activeEvent].request.operation}
+              src={event.request.operation}
               collapsed
             />
             <h3>Response</h3>
-            <ReactJson
-              name="response"
-              src={eventLog[activeEvent].response}
-              collapsed
-            />
+            <ReactJson name="response" src={event.response} collapsed />
           </Typography>
         </div>
       ) : (

--- a/src/app/EventLog.tsx
+++ b/src/app/EventLog.tsx
@@ -14,6 +14,7 @@ type EventLogProps = {
 };
 
 const EventLog = ({eventLog, handleEventChange}: EventLogProps) => {
+  console.log('eventLog ::::: ', eventLog);
   return (
     <div>
       <h1>Event Log</h1>
@@ -26,7 +27,34 @@ const EventLog = ({eventLog, handleEventChange}: EventLogProps) => {
             Event Log
           </ListSubheader>
         }>
-        {Object.keys(eventLog).map((event: any) => {
+        {eventLog.map((eventNode: any) => {
+          // DoubleLinkedList Impementation of thee EventLog
+          const {content: event} = eventNode;
+          console.log('Here is the Event Log :: ', event);
+
+          // const eventString = event.toString();
+
+          // // if statement to handle key of 0 and undefined
+          // if (
+          //   event === 0 ||
+          //   event === undefined ||
+          //   event === 'undefined' ||
+          //   event === 'queryIdCounter' ||
+          //   event === 'mutationIdCounter' ||
+          //   event === 'requestIdCounter' ||
+          //   event === 'idCounter' ||
+          //   event === 'lastEventId' ||
+          //   !event ||
+          //   event === '0' ||
+          //   eventString === '0'
+          //   // !eventLog[event].request
+          // ) {
+          //   // if key is 0 or undefined, just log it to the console and return so the next lines of code don't run
+          //   return console.log('Event === undefined', event);
+          // }
+        })}
+        {/* {Object.keys(eventLog).map((event: any) => {
+          // Object Impementation of thee EventLog
           // This might not be required, this is to ensure the event key is a string
           // However, this should be a string anyway
           const eventString = event.toString();
@@ -66,7 +94,7 @@ const EventLog = ({eventLog, handleEventChange}: EventLogProps) => {
               />
             </ListItem>
           );
-        })}
+        })} */}
       </List>
     </div>
   );

--- a/src/app/EventLog.tsx
+++ b/src/app/EventLog.tsx
@@ -27,31 +27,42 @@ const EventLog = ({eventLog, handleEventChange}: EventLogProps) => {
             Event Log
           </ListSubheader>
         }>
-        {eventLog.map((eventNode: any) => {
+        {eventLog.map((eventNode: any): any => {
           // DoubleLinkedList Impementation of thee EventLog
-          const {content: event} = eventNode;
-          console.log('Here is the Event Log :: ', event);
+          const {
+            content: {event, eventId},
+          } = eventNode; // destructure event and eventID from content node of linkedList
+          console.log('Here is the Event Node Log :: ', eventNode);
 
-          // const eventString = event.toString();
+          const eventString = eventId.toString();
 
-          // // if statement to handle key of 0 and undefined
-          // if (
-          //   event === 0 ||
-          //   event === undefined ||
-          //   event === 'undefined' ||
-          //   event === 'queryIdCounter' ||
-          //   event === 'mutationIdCounter' ||
-          //   event === 'requestIdCounter' ||
-          //   event === 'idCounter' ||
-          //   event === 'lastEventId' ||
-          //   !event ||
-          //   event === '0' ||
-          //   eventString === '0'
-          //   // !eventLog[event].request
-          // ) {
-          //   // if key is 0 or undefined, just log it to the console and return so the next lines of code don't run
-          //   return console.log('Event === undefined', event);
-          // }
+          // if statement to handle key of 0 and undefined
+          if (
+            event === 0 ||
+            event === undefined ||
+            event === 'undefined' ||
+            event === 'queryIdCounter' ||
+            event === 'mutationIdCounter' ||
+            event === 'requestIdCounter' ||
+            event === 'idCounter' ||
+            event === 'lastEventId' ||
+            !event ||
+            event === '0' ||
+            eventString === '0'
+            // !eventLog[event].request
+          ) {
+            // if key is 0 or undefined, just log it to the console and return so the next lines of code don't run
+            return console.log('Event === undefined', event);
+          }
+          // //onClick={() => handleEventChange(eventNode)}
+          return (
+            <ListItem button key={`${eventString}${0}`}>
+              <ListItemIcon>
+                <EventIcon />
+              </ListItemIcon>
+              <ListItemText primary={event.request.operation.operationName} />
+            </ListItem>
+          );
         })}
         {/* {Object.keys(eventLog).map((event: any) => {
           // Object Impementation of thee EventLog

--- a/src/app/EventLog.tsx
+++ b/src/app/EventLog.tsx
@@ -1,24 +1,18 @@
 import React from 'react';
 
-import ListSubheader from '@material-ui/core/ListSubheader';
+import EventIcon from '@material-ui/icons/Event';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
+import ListSubheader from '@material-ui/core/ListSubheader';
 
-import EventIcon from '@material-ui/icons/Event';
-
-type EventLogProps = {
-  eventLog: any;
-  handleEventChange: any;
-};
+import {EventLogProps} from './utils/managedlog/lib/eventLogData';
 
 const EventLog = ({eventLog, handleEventChange}: EventLogProps) => {
-  console.log('eventLog ::::: ', eventLog);
   return (
     <div>
       <h1>Event Log</h1>
-
       <List
         component="nav"
         aria-labelledby="nested-list-subheader"
@@ -27,43 +21,49 @@ const EventLog = ({eventLog, handleEventChange}: EventLogProps) => {
             Event Log
           </ListSubheader>
         }>
-        {eventLog.map((eventNode: any): any => {
-          // DoubleLinkedList Impementation of thee EventLog
-          const {
-            content: {event, eventId},
-          } = eventNode; // destructure event and eventID from content node of linkedList
-          console.log('Here is the Event Node Log :: ', eventNode);
+        {eventLog.eventLength ? (
+          eventLog.map((eventNode: any): any => {
+            // DoubleLinkedList Impementation of thee EventLog
+            const {
+              content: {event, eventId},
+            } = eventNode; // destructure event and eventID from content node of linkedList
 
-          const eventString = eventId.toString();
+            const eventString = eventId.toString();
 
-          // if statement to handle key of 0 and undefined
-          if (
-            event === 0 ||
-            event === undefined ||
-            event === 'undefined' ||
-            event === 'queryIdCounter' ||
-            event === 'mutationIdCounter' ||
-            event === 'requestIdCounter' ||
-            event === 'idCounter' ||
-            event === 'lastEventId' ||
-            !event ||
-            event === '0' ||
-            eventString === '0'
-            // !eventLog[event].request
-          ) {
-            // if key is 0 or undefined, just log it to the console and return so the next lines of code don't run
-            return console.log('Event === undefined', event);
-          }
-          // //onClick={() => handleEventChange(eventNode)}
-          return (
-            <ListItem button key={`${eventString}${0}`}>
-              <ListItemIcon>
-                <EventIcon />
-              </ListItemIcon>
-              <ListItemText primary={event.request.operation.operationName} />
-            </ListItem>
-          );
-        })}
+            // if statement to handle key of 0 and undefined
+            if (
+              event === 0 ||
+              event === undefined ||
+              event === 'undefined' ||
+              event === 'queryIdCounter' ||
+              event === 'mutationIdCounter' ||
+              event === 'requestIdCounter' ||
+              event === 'idCounter' ||
+              event === 'lastEventId' ||
+              !event ||
+              event === '0' ||
+              eventString === '0'
+              // !eventLog[event].request
+            ) {
+              // if key is 0 or undefined, just log it to the console and return so the next lines of code don't run
+              return console.log('Event === undefined', event);
+            }
+
+            return (
+              <ListItem
+                button
+                key={`${eventString}${0}`}
+                onClick={() => handleEventChange(eventNode)}>
+                <ListItemIcon>
+                  <EventIcon />
+                </ListItemIcon>
+                <ListItemText primary={event.request.operation.operationName} />
+              </ListItem>
+            );
+          })
+        ) : (
+          <></>
+        )}
         {/* {Object.keys(eventLog).map((event: any) => {
           // Object Impementation of thee EventLog
           // This might not be required, this is to ensure the event key is a string

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -3,11 +3,16 @@ import React, {useState, useEffect} from 'react';
 import MainDrawer from './MainDrawer';
 import createURICacheEventListener, {getApolloClient} from './utils/messaging';
 import createNetworkEventListener from './utils/networking';
+import EventLogDataObject from './utils/managedlog/lib/eventLogData';
+import EventLogContainer from './utils/managedlog/eventObject';
 
 const App = () => {
+  // const eventLogList = new EventLogDataObject();
+  // const EventList = EventLogContainer(eventLogList);
+  const EventList = EventLogContainer(new EventLogDataObject());
   const [apolloURI, setApolloURI] = useState('');
   const [networkURI, setNetworkURI] = useState('');
-  const [events, setEvents] = useState({});
+  const [events, setEvents] = useState(() => EventList.getDataStore());
   const [stores, setStores] = useState({});
   const [networkEvents, setNetworkEvents] = useState({});
 
@@ -15,7 +20,7 @@ const App = () => {
   useEffect(() => {
     // Event listener to obtain the GraphQL server endpoint (URI)
     // and the cache from the Apollo Client
-    createURICacheEventListener(setApolloURI, setStores);
+    createURICacheEventListener(setApolloURI, setStores, EventList, setEvents);
 
     // Initial load of the App, so send a message to the contentScript to get the cache
     getApolloClient();

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,10 +1,11 @@
 import React, {useState, useEffect} from 'react';
 
-import MainDrawer from './MainDrawer';
-import createURICacheEventListener, {getApolloClient} from './utils/messaging';
 import createNetworkEventListener from './utils/networking';
+import createURICacheEventListener, {getApolloClient} from './utils/messaging';
 import EventLogDataObject from './utils/managedlog/lib/eventLogData';
 import EventLogContainer from './utils/managedlog/eventObject';
+import {EventStore} from './utils/managedlog/lib/apollo11types';
+import MainDrawer from './MainDrawer';
 
 const App = () => {
   // const eventLogList = new EventLogDataObject();
@@ -12,8 +13,10 @@ const App = () => {
   const EventList = EventLogContainer(new EventLogDataObject());
   const [apolloURI, setApolloURI] = useState('');
   const [networkURI, setNetworkURI] = useState('');
-  const [events, setEvents] = useState(() => EventList.getDataStore());
-  const [stores, setStores] = useState({});
+  const [events, setEvents] = useState<EventLogDataObject>(() =>
+    EventList.getDataStore(),
+  );
+  const [stores, setStores] = useState<EventStore>({});
   const [networkEvents, setNetworkEvents] = useState({});
 
   // Only create the listener when the App is initially mounted
@@ -31,9 +34,21 @@ const App = () => {
 
   useEffect(() => {
     console.log('Current stores :>> ', stores);
+    // if (stores && stores.lastEventId) {
+    //   console.log('Curretn lastest Stores Id :: ', stores.lastEventId);
+    //   const storeIdx = stores.lastEventId;
+    //   EventList.sequenceApolloLog(
+    //     {
+    //       queryManager: (stores[storeIdx] as any).queryManager,
+    //       eventId: stores.lastEventId,
+    //       cache: (stores[storeIdx] as any).cache,
+    //     },
+    //     setEvents,
+    //   );
+    // }
     // do something with the stores
     // ie update the actual Event Log
-  }, [stores]);
+  }, [stores]); // EventList
 
   useEffect(() => {
     console.log('Current Event Log :>>', events);

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -3,14 +3,16 @@ import React, {useState, useEffect} from 'react';
 import createNetworkEventListener from './utils/networking';
 import createURICacheEventListener, {getApolloClient} from './utils/messaging';
 import EventLogDataObject from './utils/managedlog/lib/eventLogData';
-import EventLogContainer from './utils/managedlog/eventObject';
+import EventLogTreeContainer, {
+  EventLogContainer,
+} from './utils/managedlog/eventObject';
 import {EventStore} from './utils/managedlog/lib/apollo11types';
 import MainDrawer from './MainDrawer';
 
 const App = () => {
   // const eventLogList = new EventLogDataObject();
-  // const EventList = EventLogContainer(eventLogList);
-  const EventList = EventLogContainer(new EventLogDataObject());
+  // const EventList = EventLogTreeContainer(eventLogList);
+  const EventList = EventLogTreeContainer(new EventLogDataObject());
   const [apolloURI, setApolloURI] = useState('');
   const [networkURI, setNetworkURI] = useState('');
   const [events, setEvents] = useState<EventLogDataObject>(() =>

--- a/src/app/utils/managedlog/__tests__/dll.ts
+++ b/src/app/utils/managedlog/__tests__/dll.ts
@@ -228,10 +228,16 @@ dllStructure.addEventLog(eventNode3);
 // console.log(dllStructure.map(e => e));
 
 dllStructure2.addEventLog(eventNode3);
-dllStructure2.addEventLog(eventNode2);
+// dllStructure2.addEventLog(eventNode2);
 
 console.log('First DLL ::', dllStructure);
+console.log(dllStructure.debugPrint());
 console.log('Second DLL ::', dllStructure2);
+console.log(dllStructure2.debugPrint());
+
+dllStructure.append(dllStructure2);
+console.log('New DLL ::', dllStructure);
+console.log(dllStructure.debugPrint());
 
 // const allStructures = dllStructure.addEventLog(dllStructure2.eventHead);
 // const allStructures = dllStructure.insertEventLogAfter(

--- a/src/app/utils/managedlog/__tests__/dll.ts
+++ b/src/app/utils/managedlog/__tests__/dll.ts
@@ -2,9 +2,9 @@ import EventNode from '../lib/eventLogNode';
 import EventLogDataObject from '../lib/eventLogData';
 import {EventLogObject} from '../lib/apollo11types';
 
-let dllStructure = new EventLogDataObject();
+const dllStructure = new EventLogDataObject();
 
-let eventNode1 = new EventNode({
+const evtNode1: EventLogObject = {
   event: {
     mutation: {
       kind: 'Document',
@@ -16,9 +16,10 @@ let eventNode1 = new EventNode({
   },
   type: 'query',
   eventId: '099087779',
-} as EventLogObject);
+};
+const eventNode1 = new EventNode(evtNode1);
 
-let eventNode2 = new EventNode({
+const evtNode2: EventLogObject = {
   event: {
     mutation: {
       kind: 'Document',
@@ -107,9 +108,10 @@ let eventNode2 = new EventNode({
   },
   type: 'mutation',
   eventId: '099087780',
-} as EventLogObject);
+};
+const eventNode2 = new EventNode(evtNode2);
 
-let eventNode3 = new EventNode({
+const evtNode3: EventLogObject = {
   event: {
     mutation: {
       kind: 'Document',
@@ -213,7 +215,8 @@ let eventNode3 = new EventNode({
   },
   type: 'mutation',
   eventId: '099087787',
-} as EventLogObject);
+};
+const eventNode3 = new EventNode(evtNode3);
 
 dllStructure.addEventLog(eventNode1);
 // console.log(dllStructure);

--- a/src/app/utils/managedlog/__tests__/dll.ts
+++ b/src/app/utils/managedlog/__tests__/dll.ts
@@ -3,6 +3,7 @@ import EventLogDataObject from '../lib/eventLogData';
 import {EventLogObject} from '../lib/apollo11types';
 
 const dllStructure = new EventLogDataObject();
+const dllStructure2 = new EventLogDataObject();
 
 const evtNode1: EventLogObject = {
   event: {
@@ -224,4 +225,25 @@ dllStructure.addEventLog(eventNode2);
 // console.log(dllStructure);
 dllStructure.addEventLog(eventNode3);
 // console.log(dllStructure);
-console.log(dllStructure.map(e => e));
+// console.log(dllStructure.map(e => e));
+
+dllStructure2.addEventLog(eventNode3);
+dllStructure2.addEventLog(eventNode2);
+
+console.log('First DLL ::', dllStructure);
+console.log('Second DLL ::', dllStructure2);
+
+// const allStructures = dllStructure.addEventLog(dllStructure2.eventHead);
+// const allStructures = dllStructure.insertEventLogAfter(
+//   dllStructure.eventTail,
+//   dllStructure2.eventHead,
+// );
+// console.log('Addition of BOTH');
+// console.log(allStructures);
+
+// let nde = allStructures.eventHead;
+// while (nde) {
+//   console.log('NDE :: ', nde);
+//   console.log(nde.content.eventId);
+//   nde = nde.next;
+// }

--- a/src/app/utils/managedlog/__tests__/dll.ts
+++ b/src/app/utils/managedlog/__tests__/dll.ts
@@ -216,8 +216,9 @@ let eventNode3 = new EventNode({
 } as EventLogObject);
 
 dllStructure.addEventLog(eventNode1);
-console.log(dllStructure);
+// console.log(dllStructure);
 dllStructure.addEventLog(eventNode2);
-console.log(dllStructure);
+// console.log(dllStructure);
 dllStructure.addEventLog(eventNode3);
-console.log(dllStructure);
+// console.log(dllStructure);
+console.log(dllStructure.map(e => e));

--- a/src/app/utils/managedlog/__tests__/dll.ts
+++ b/src/app/utils/managedlog/__tests__/dll.ts
@@ -1,0 +1,223 @@
+import EventNode from '../lib/eventLogNode';
+import EventLogDataObject from '../lib/eventLogData';
+import {EventLogObject} from '../lib/apollo11types';
+
+let dllStructure = new EventLogDataObject();
+
+let eventNode1 = new EventNode({
+  event: {
+    mutation: {
+      kind: 'Document',
+      definitions: [],
+    },
+    variables: {},
+    loading: false,
+    error: null,
+  },
+  type: 'query',
+  eventId: '099087779',
+} as EventLogObject);
+
+let eventNode2 = new EventNode({
+  event: {
+    mutation: {
+      kind: 'Document',
+      definitions: [
+        {
+          kind: 'OperationDefinition',
+          operation: 'mutation',
+          name: {kind: 'Name', value: 'newBookTrips'},
+          variableDefinitions: [],
+          directives: [],
+          selectionSet: {
+            kind: 'SelectionSet',
+            selections: [
+              {
+                kind: 'Field',
+                name: {kind: 'Name', value: 'newbookTrips'},
+                arguments: [
+                  {
+                    kind: 'Argument',
+                    name: {kind: 'Name', value: 'newlaunchIds'},
+                    value: {
+                      kind: 'Variable',
+                      name: {kind: 'Name', value: 'newlaunchIds'},
+                    },
+                  },
+                ],
+                directives: [],
+                selectionSet: {
+                  kind: 'SelectionSet',
+                  selections: [
+                    {
+                      kind: 'Field',
+                      name: {kind: 'Name', value: 'success'},
+                      arguments: [],
+                      directives: [],
+                    },
+                    {
+                      kind: 'Field',
+                      name: {kind: 'Name', value: 'message'},
+                      arguments: [],
+                      directives: [],
+                    },
+                    {
+                      kind: 'Field',
+                      name: {kind: 'Name', value: 'launches'},
+                      arguments: [],
+                      directives: [],
+                      selectionSet: {
+                        kind: 'SelectionSet',
+                        selections: [
+                          {
+                            kind: 'Field',
+                            name: {kind: 'Name', value: 'id'},
+                            arguments: [],
+                            directives: [],
+                          },
+                          {
+                            kind: 'Field',
+                            name: {kind: 'Name', value: 'isBooked'},
+                            arguments: [],
+                            directives: [],
+                          },
+                          {
+                            kind: 'Field',
+                            name: {kind: 'Name', value: '__typename'},
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      kind: 'Field',
+                      name: {kind: 'Name', value: '__typename'},
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+      // loc: {start: 0, end: 173},
+    },
+    variables: {launchIds: ['100']},
+    loading: false,
+    error: null,
+  },
+  type: 'mutation',
+  eventId: '099087780',
+} as EventLogObject);
+
+let eventNode3 = new EventNode({
+  event: {
+    mutation: {
+      kind: 'Document',
+      definitions: [
+        {
+          kind: 'OperationDefinition',
+          operation: 'mutation',
+          name: {kind: 'Name', value: 'cancel'},
+          variableDefinitions: [
+            {
+              kind: 'VariableDefinition',
+              variable: {
+                kind: 'Variable',
+                name: {kind: 'Name', value: 'launchId'},
+              },
+              type: {
+                kind: 'NonNullType',
+                type: {
+                  kind: 'NamedType',
+                  name: {kind: 'Name', value: 'ID'},
+                },
+              },
+              directives: [],
+            },
+          ],
+          directives: [],
+          selectionSet: {
+            kind: 'SelectionSet',
+            selections: [
+              {
+                kind: 'Field',
+                name: {kind: 'Name', value: 'cancelTrip'},
+                arguments: [
+                  {
+                    kind: 'Argument',
+                    name: {kind: 'Name', value: 'launchId'},
+                    value: {
+                      kind: 'Variable',
+                      name: {kind: 'Name', value: 'launchId'},
+                    },
+                  },
+                ],
+                directives: [],
+                selectionSet: {
+                  kind: 'SelectionSet',
+                  selections: [
+                    {
+                      kind: 'Field',
+                      name: {kind: 'Name', value: 'success'},
+                      arguments: [],
+                      directives: [],
+                    },
+                    {
+                      kind: 'Field',
+                      name: {kind: 'Name', value: 'message'},
+                      arguments: [],
+                      directives: [],
+                    },
+                    {
+                      kind: 'Field',
+                      name: {kind: 'Name', value: 'launches'},
+                      arguments: [],
+                      directives: [],
+                      selectionSet: {
+                        kind: 'SelectionSet',
+                        selections: [
+                          {
+                            kind: 'Field',
+                            name: {kind: 'Name', value: 'id'},
+                            arguments: [],
+                            directives: [],
+                          },
+                          {
+                            kind: 'Field',
+                            name: {kind: 'Name', value: 'isBooked'},
+                            arguments: [],
+                            directives: [],
+                          },
+                          {
+                            kind: 'Field',
+                            name: {kind: 'Name', value: '__typename'},
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      kind: 'Field',
+                      name: {kind: 'Name', value: '__typename'},
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    variables: {launchId: '101'},
+    loading: true,
+    error: null,
+  },
+  type: 'mutation',
+  eventId: '099087787',
+} as EventLogObject);
+
+dllStructure.addEventLog(eventNode1);
+console.log(dllStructure);
+dllStructure.addEventLog(eventNode2);
+console.log(dllStructure);
+dllStructure.addEventLog(eventNode3);
+console.log(dllStructure);

--- a/src/app/utils/managedlog/__tests__/index.ts
+++ b/src/app/utils/managedlog/__tests__/index.ts
@@ -1,18 +1,25 @@
 import {EventBase} from '../lib/apollo11types';
 import eventLogIsDifferent from '../lib/objectDifference';
-import eventLogDataObject from '../lib/eventLogData';
-import EventLogContainer from '../eventObject';
+import EventLogDataObject from '../lib/eventLogData';
+import EventLogContainer, {EventStore} from '../eventObject';
 
 // TESTS
-const testobj = EventLogContainer(eventLogDataObject);
-const testEvtLog: EventBase = {
-  mutation: {3: {}, 4: {}},
-  query: {1: {}, 2: {}},
+const testobj = EventLogContainer(new EventLogDataObject());
+// const testEvtLog: EventBase = {
+//   mutation: {3: {}, 4: {}},
+//   query: {1: {}, 2: {}},
+// };
+const testStore: EventStore = {
+  queryManager: {
+    mutationStore: {3: {}, 4: {}},
+    queriesStore: {1: {}, 2: {}},
+  },
+  eventId: '1600905405018',
 };
 console.log('===== EventContainer Object ====');
 console.log(testobj);
 console.log('===== Sample EventLog to Sequence ====');
-console.log(testobj.sequenceApolloLog(testEvtLog));
+console.log(testobj.sequenceApolloLog(testStore));
 console.log('===== EventContainer DataStore ====');
 console.log(testobj.getDataStore());
 console.log('===== EventBase Local Container Store ====');

--- a/src/app/utils/managedlog/__tests__/index.ts
+++ b/src/app/utils/managedlog/__tests__/index.ts
@@ -1,0 +1,19 @@
+import {EventBase} from '../lib/apollo11types';
+import eventLogIsDifferent from '../lib/objectDifference';
+import eventLogDataObject from '../lib/eventLogData';
+import EventLogContainer from '../eventObject';
+
+// TESTS
+const testobj = EventLogContainer(eventLogDataObject);
+const testEvtLog: EventBase = {
+  mutation: {3: {}, 4: {}},
+  query: {1: {}, 2: {}},
+};
+console.log('===== EventContainer Object ====');
+console.log(testobj);
+console.log('===== Sample EventLog to Sequence ====');
+console.log(testobj.sequenceApolloLog(testEvtLog));
+console.log('===== EventContainer DataStore ====');
+console.log(testobj.getDataStore());
+console.log('===== EventBase Local Container Store ====');
+console.log(testobj.getTempStore());

--- a/src/app/utils/managedlog/__tests__/index.ts
+++ b/src/app/utils/managedlog/__tests__/index.ts
@@ -1,10 +1,10 @@
 // import {EventStore} from '../lib/apollo11types';
 import EventLogDataObject from '../lib/eventLogData';
-import EventLogContainer, {EventLogStore} from '../eventObject';
+import EventLogTreeContainer, {EventLogStore} from '../eventObject';
 // import eventLogIsDifferent from '../lib/objectDifference';
 
 // TESTS
-const testobj = EventLogContainer(new EventLogDataObject());
+const testobj = EventLogTreeContainer(new EventLogDataObject());
 // const testEvtLog: EventBase = {
 //   mutation: {3: {}, 4: {}},
 //   query: {1: {}, 2: {}},

--- a/src/app/utils/managedlog/__tests__/index.ts
+++ b/src/app/utils/managedlog/__tests__/index.ts
@@ -1,7 +1,7 @@
-import {EventBase} from '../lib/apollo11types';
+// import {EventBase} from '../lib/apollo11types';
 import EventLogDataObject from '../lib/eventLogData';
 import EventLogContainer, {EventStore} from '../eventObject';
-import eventLogIsDifferent from '../lib/objectDifference';
+// import eventLogIsDifferent from '../lib/objectDifference';
 
 // TESTS
 const testobj = EventLogContainer(new EventLogDataObject());

--- a/src/app/utils/managedlog/__tests__/index.ts
+++ b/src/app/utils/managedlog/__tests__/index.ts
@@ -1,7 +1,7 @@
 import {EventBase} from '../lib/apollo11types';
-import eventLogIsDifferent from '../lib/objectDifference';
 import EventLogDataObject from '../lib/eventLogData';
 import EventLogContainer, {EventStore} from '../eventObject';
+import eventLogIsDifferent from '../lib/objectDifference';
 
 // TESTS
 const testobj = EventLogContainer(new EventLogDataObject());

--- a/src/app/utils/managedlog/__tests__/index.ts
+++ b/src/app/utils/managedlog/__tests__/index.ts
@@ -1,6 +1,6 @@
-// import {EventBase} from '../lib/apollo11types';
+// import {EventStore} from '../lib/apollo11types';
 import EventLogDataObject from '../lib/eventLogData';
-import EventLogContainer, {EventStore} from '../eventObject';
+import EventLogContainer, {EventLogStore} from '../eventObject';
 // import eventLogIsDifferent from '../lib/objectDifference';
 
 // TESTS
@@ -9,7 +9,7 @@ const testobj = EventLogContainer(new EventLogDataObject());
 //   mutation: {3: {}, 4: {}},
 //   query: {1: {}, 2: {}},
 // };
-const testStore: EventStore = {
+const testStore: EventLogStore = {
   queryManager: {
     mutationStore: {3: {}, 4: {}},
     queriesStore: {1: {}, 2: {}},

--- a/src/app/utils/managedlog/eventObject.ts
+++ b/src/app/utils/managedlog/eventObject.ts
@@ -1,20 +1,25 @@
 export interface EventBase {}
 
-export interface EventType {}
+interface EventDesc {
+  [k: string]: number | string | undefined | any[] | EventDesc;
+}
+interface EventObject {
+  [k: string]: string | boolean | EventDesc;
+}
 
 export class EventNode {
-  content: EventType;
+  content: EventObject;
   prev: EventNode | null;
   next: EventNode | null;
 
-  constructor(content: EventType) {
+  constructor(content: EventObject) {
     this.content = content;
     this.prev = null;
     this.next = null;
   }
 }
 
-export class EventLogContainer {
+class EventLogContainer {
   eventHead: EventNode | null;
   eventTail: EventNode | null;
   private eventsBase: EventBase | null;
@@ -62,11 +67,11 @@ export class EventLogContainer {
     // Write your code here.
   }
 
-  insertEventLogAtPosition(position: EventType, nodeToInsert: EventNode) {
+  insertEventLogAtPosition(position: EventObject, nodeToInsert: EventNode) {
     // Write your code here.
   }
 
-  removeEventLogNodesWithContent(conten: EventType) {
+  removeEventLogNodesWithContent(conten: EventObject) {
     // Write your code here.
   }
 
@@ -74,8 +79,10 @@ export class EventLogContainer {
     // Write your code here.
   }
 
-  containsEventNodeWithContent(content: EventType) {
+  containsEventNodeWithContent(content: EventObject) {
     // Write your code here.
     return false;
   }
 }
+
+export default new EventLogContainer();

--- a/src/app/utils/managedlog/eventObject.ts
+++ b/src/app/utils/managedlog/eventObject.ts
@@ -4,7 +4,7 @@ import eventLogIsDifferent from './lib/objectDifference';
 import EventLogDataObject from './lib/eventLogData';
 import EventNode from './lib/eventLogNode';
 
-export type EventStore = {
+export type EventLogStore = {
   eventId: string;
   queryManager: {
     mutationStore: Object;
@@ -35,7 +35,15 @@ export class EventLogContainer {
     this._eventsBase[eventNode.content.type][baseId] = eventNode.content.event;
     if (setEvents) {
       // perform the State Hook
-      setEvents(() => {
+      setEvents((preEvents: EventLogDataObject) => {
+        console.log('Previous Events :: ', preEvents);
+        console.log('New Events :: ', this._eventLogData);
+        // const allEvents = this._eventLogData.insertEventLogAfter(
+        //   preEvents.eventTail,
+        //   this._eventLogData.eventHead,
+        // );
+        // console.log('All Events :: ', allEvents);
+        // preEvents.addEventLog(this._eventLogData.eventHead);
         return this._eventLogData;
       });
     }
@@ -48,7 +56,7 @@ export class EventLogContainer {
   }
 
   sequenceApolloLog(
-    eventLog: EventStore,
+    eventLog: EventLogStore,
     setEvents?: React.Dispatch<React.SetStateAction<{}>>,
   ) {
     const {
@@ -59,7 +67,7 @@ export class EventLogContainer {
     let evtNum = 0;
     // perform queriesStore Check
     Object.keys(queriesStore).forEach(storeKey => {
-      console.log('Query Snapshot :: ', queriesStore[storeKey]);
+      // console.log('Query Snapshot :: ', queriesStore[storeKey]);
       const proposedQry: EventNode = new EventNode({
         event: {
           ...queriesStore[storeKey],
@@ -76,7 +84,7 @@ export class EventLogContainer {
         eventId: this.adjustEventId(eventId, (evtNum += 1)),
         cache,
       });
-      console.log('Proposed Query Snapshot :: ', proposedQry);
+      // console.log('Proposed Query Snapshot :: ', proposedQry);
       if (!this._eventsBase.query[storeKey]) {
         this.logEvent(proposedQry, storeKey, setEvents);
       } else {
@@ -101,7 +109,7 @@ export class EventLogContainer {
     });
     // perform mutationStore Check
     Object.keys(mutationStore).forEach(storeKey => {
-      console.log('Mutation Snapshot :: ', mutationStore[storeKey]);
+      // console.log('Mutation Snapshot :: ', mutationStore[storeKey]);
       const proposedMutate: EventNode = new EventNode({
         event: {
           ...mutationStore[storeKey],
@@ -118,7 +126,7 @@ export class EventLogContainer {
         eventId: this.adjustEventId(eventId, (evtNum += 1)),
         cache,
       });
-      console.log('Proposed Mutation Snapshot :: ', proposedMutate);
+      // console.log('Proposed Mutation Snapshot :: ', proposedMutate);
       if ((proposedMutate.content.event as MutationStoreValue).loading) {
         return;
       }

--- a/src/app/utils/managedlog/eventObject.ts
+++ b/src/app/utils/managedlog/eventObject.ts
@@ -50,16 +50,22 @@ export class EventLogContainer {
     } = eventLog;
     // perform queriesStore Check
     Object.keys(queriesStore).forEach(storeKey => {
+      const proposedQry: EventNode = new EventNode({
+        event: {
+          ...queriesStore[storeKey],
+          request: {
+            operation: {
+              operationName:
+                queriesStore[storeKey].document.definitions[0].name.value,
+              query: queriesStore[storeKey].document.loc.source.body,
+            },
+          },
+        },
+        type: 'query',
+        eventId,
+      });
       if (!this.eventsBase.query[storeKey]) {
-        this.logEvent(
-          new EventNode({
-            event: queriesStore[storeKey],
-            type: 'query',
-            eventId,
-          }),
-          storeKey,
-          setEvents,
-        );
+        this.logEvent(proposedQry, storeKey, setEvents);
       } else {
         // perform the diff
         if (
@@ -74,30 +80,28 @@ export class EventLogContainer {
             },
           )
         ) {
-          this.logEvent(
-            new EventNode({
-              event: queriesStore[storeKey],
-              type: 'query',
-              eventId,
-            }),
-            storeKey,
-            setEvents,
-          );
+          this.logEvent(proposedQry, storeKey, setEvents);
         }
       }
     });
     // perform mutationStore Check
     Object.keys(mutationStore).forEach(storeKey => {
+      const proposedMutate: EventNode = new EventNode({
+        event: {
+          ...mutationStore[storeKey],
+          request: {
+            operation: {
+              operationName:
+                mutationStore[storeKey].mutation.definitions[0].name.value,
+              query: mutationStore[storeKey].mutation.loc.source.body,
+            },
+          },
+        },
+        type: 'mutation',
+        eventId,
+      });
       if (!this.eventsBase.mutation[storeKey]) {
-        this.logEvent(
-          new EventNode({
-            event: mutationStore[storeKey],
-            type: 'mutation',
-            eventId,
-          }),
-          storeKey,
-          setEvents,
-        );
+        this.logEvent(proposedMutate, storeKey, setEvents);
       } else {
         // perform the diff
         if (
@@ -112,15 +116,7 @@ export class EventLogContainer {
             },
           )
         ) {
-          this.logEvent(
-            new EventNode({
-              event: mutationStore[storeKey],
-              type: 'mutation',
-              eventId,
-            }),
-            storeKey,
-            setEvents,
-          );
+          this.logEvent(proposedMutate, storeKey, setEvents);
         }
       }
     });

--- a/src/app/utils/managedlog/eventObject.ts
+++ b/src/app/utils/managedlog/eventObject.ts
@@ -1,10 +1,13 @@
-export interface EventBase {}
-
 interface EventDesc {
   [k: string]: number | string | undefined | any[] | EventDesc;
 }
 interface EventObject {
   [k: string]: string | boolean | EventDesc;
+}
+
+export interface EventBase {
+  mutation: EventObject[];
+  query: EventObject[];
 }
 
 export class EventNode {
@@ -30,6 +33,98 @@ class EventLogContainer {
     this.eventsBase = null;
   }
 
+  // <T>sequenceApolloLog(obj<T>: any) {
+
+  // }
+
+  setEventHead(content: EventNode) {
+    if (this.eventHead === null) {
+      this.eventHead = this.eventTail = content;
+    } else {
+      this.insertEventLogBefore(this.eventHead, content);
+    }
+  }
+
+  addEventLog(content: EventNode) {
+    if (this.eventTail === null) {
+      this.setEventHead(content);
+    } else {
+      this.insertEventLogAfter(this.eventTail, content);
+    }
+  }
+
+  insertEventLogBefore(content: EventNode, nodeToInsert: EventNode) {
+    if (this.isNodeTailAndHead(nodeToInsert)) return;
+    this.removeEventLogNode(content);
+    nodeToInsert.prev = content.prev;
+    nodeToInsert.next = content;
+    if (content.prev === null) {
+      this.eventHead = nodeToInsert;
+    } else {
+      content.prev.next = nodeToInsert;
+    }
+    content.prev = nodeToInsert;
+  }
+
+  insertEventLogAfter(content: EventNode, nodeToInsert: EventNode) {
+    if (this.isNodeTailAndHead(nodeToInsert)) return;
+    this.removeEventLogNode(content);
+    nodeToInsert.prev = content;
+    nodeToInsert.next = content.next;
+    if (content.next === null) {
+      this.eventTail = nodeToInsert;
+    } else {
+      content.next.prev = nodeToInsert;
+    }
+  }
+
+  insertEventLogAtPosition(position: number, nodeToInsert: EventNode) {
+    if (position === 1) {
+      this.setEventHead(nodeToInsert);
+    } else {
+      let eNode = this.eventHead;
+      let currentPosition = 1;
+      while (eNode !== null && currentPosition++ !== position)
+        eNode = eNode.next;
+      if (eNode !== null) {
+        this.insertEventLogBefore(eNode, nodeToInsert);
+      } else {
+        this.addEventLog(nodeToInsert);
+      }
+    }
+  }
+
+  removeEventLogNodesWithContent(content: EventObject) {
+    let eNode = this.eventHead;
+    while (eNode !== null) {
+      const proposedToRemove = eNode;
+      eNode = eNode.next;
+      if (this.eventLogIsDifferent(eNode.content, content))
+        this.removeEventLogNode(proposedToRemove);
+    }
+  }
+
+  removeEventLogNode(content: EventNode) {
+    if (content === this.eventHead) this.eventHead = this.eventHead.next;
+    if (content === this.eventTail) this.eventTail = this.eventTail.prev;
+    // cleanup removed EventNode pointers
+    this.removeEventNodePointers(content);
+  }
+
+  containsEventNodeWithContent(content: EventObject) {
+    if (!content) {
+      let eNode = this.eventHead;
+      while (
+        eNode !== null &&
+        !this.eventLogIsDifferent(eNode.content, content)
+      ) {
+        eNode = eNode.next;
+      }
+      return eNode === null;
+    }
+    return false;
+  }
+
   isLogValuePrimitive(val: any): boolean {
     return val == null || /^[sbn]/.test(typeof val);
   }
@@ -51,37 +146,15 @@ class EventLogContainer {
     );
   }
 
-  setEventHead(node: Node) {
-    // Write your code here.
+  isNodeTailAndHead(nodeToInsert: EventNode) {
+    return nodeToInsert === this.eventHead && nodeToInsert === this.eventTail;
   }
 
-  setEventTail(node: Node) {
-    // Write your code here.
-  }
-
-  insertEventLogBefore(node: EventNode, nodeToInsert: EventNode) {
-    // Write your code here.
-  }
-
-  insertEventLogAfter(node: EventNode, nodeToInsert: EventNode) {
-    // Write your code here.
-  }
-
-  insertEventLogAtPosition(position: EventObject, nodeToInsert: EventNode) {
-    // Write your code here.
-  }
-
-  removeEventLogNodesWithContent(conten: EventObject) {
-    // Write your code here.
-  }
-
-  removeEventLogNode(node: EventNode) {
-    // Write your code here.
-  }
-
-  containsEventNodeWithContent(content: EventObject) {
-    // Write your code here.
-    return false;
+  removeEventNodePointers(content: EventNode) {
+    if (content.prev !== null) content.prev.next = content.next;
+    if (content.next !== null) content.next.prev = content.prev;
+    content.prev = null;
+    content.next = null;
   }
 }
 

--- a/src/app/utils/managedlog/eventObject.ts
+++ b/src/app/utils/managedlog/eventObject.ts
@@ -29,19 +29,8 @@ class EventLogContainer<T> {
   }
 }
 
-// // TESTS
-// const testobj = new EventLogContainer(new eventLogDataObject());
-// const testEvtLog: EventBase = {
-//   mutation: {3: {}, 4: {}},
-//   query: {1: {}, 2: {}},
-// };
-// console.log('===== EventContainer Object ====');
-// console.log(testobj);
-// console.log('===== Sample EventLog to Sequence ====');
-// console.log(testobj.sequenceApolloLog(testEvtLog));
-// console.log('===== EventContainer DataStore ====');
-// console.log(testobj.getDataStore());
-// console.log('===== EventBase Local Container Store ====');
-// console.log(testobj.getTempStore());
+// export default new EventLogContainer(new eventLogDataObject());
 
-export default new EventLogContainer(new eventLogDataObject());
+export default <T>(LogObject: new () => T): EventLogContainer<T> => {
+  return new EventLogContainer<T>(new LogObject());
+};

--- a/src/app/utils/managedlog/eventObject.ts
+++ b/src/app/utils/managedlog/eventObject.ts
@@ -1,161 +1,47 @@
-interface EventDesc {
-  [k: string]: number | string | undefined | any[] | EventDesc;
-}
-interface EventObject {
-  [k: string]: string | boolean | EventDesc;
-}
+import {EventBase} from './lib/apollo11types';
+import eventLogIsDifferent from './lib/objectDifference';
+import eventLogDataObject from './lib/eventLogData';
 
-export interface EventBase {
-  mutation: EventObject[];
-  query: EventObject[];
-}
+class EventLogContainer<T> {
+  private eventsBase: EventBase | undefined;
 
-export class EventNode {
-  content: EventObject;
-  prev: EventNode | null;
-  next: EventNode | null;
+  private eventLogData: T | undefined;
 
-  constructor(content: EventObject) {
-    this.content = content;
-    this.prev = null;
-    this.next = null;
+  constructor(srceObj?: T) {
+    this.eventLogData = srceObj;
+    this.eventsBase = {
+      mutation: {},
+      query: {},
+    };
+  }
+
+  sequenceApolloLog<U>(eventLog: U) {
+    this.eventsBase[0] = eventLog;
+    console.log('EventLog to Sequence :: ', eventLog);
+  }
+
+  getDataStore() {
+    return this.eventLogData;
+  }
+
+  getTempStore() {
+    return this.eventsBase;
   }
 }
 
-class EventLogContainer {
-  eventHead: EventNode | null;
-  eventTail: EventNode | null;
-  private eventsBase: EventBase | null;
+// // TESTS
+// const testobj = new EventLogContainer(new eventLogDataObject());
+// const testEvtLog: EventBase = {
+//   mutation: {3: {}, 4: {}},
+//   query: {1: {}, 2: {}},
+// };
+// console.log('===== EventContainer Object ====');
+// console.log(testobj);
+// console.log('===== Sample EventLog to Sequence ====');
+// console.log(testobj.sequenceApolloLog(testEvtLog));
+// console.log('===== EventContainer DataStore ====');
+// console.log(testobj.getDataStore());
+// console.log('===== EventBase Local Container Store ====');
+// console.log(testobj.getTempStore());
 
-  constructor() {
-    this.eventHead = null;
-    this.eventTail = null;
-    this.eventsBase = null;
-  }
-
-  // <T>sequenceApolloLog(obj<T>: any) {
-
-  // }
-
-  setEventHead(content: EventNode) {
-    if (this.eventHead === null) {
-      this.eventHead = this.eventTail = content;
-    } else {
-      this.insertEventLogBefore(this.eventHead, content);
-    }
-  }
-
-  addEventLog(content: EventNode) {
-    if (this.eventTail === null) {
-      this.setEventHead(content);
-    } else {
-      this.insertEventLogAfter(this.eventTail, content);
-    }
-  }
-
-  insertEventLogBefore(content: EventNode, nodeToInsert: EventNode) {
-    if (this.isNodeTailAndHead(nodeToInsert)) return;
-    this.removeEventLogNode(content);
-    nodeToInsert.prev = content.prev;
-    nodeToInsert.next = content;
-    if (content.prev === null) {
-      this.eventHead = nodeToInsert;
-    } else {
-      content.prev.next = nodeToInsert;
-    }
-    content.prev = nodeToInsert;
-  }
-
-  insertEventLogAfter(content: EventNode, nodeToInsert: EventNode) {
-    if (this.isNodeTailAndHead(nodeToInsert)) return;
-    this.removeEventLogNode(content);
-    nodeToInsert.prev = content;
-    nodeToInsert.next = content.next;
-    if (content.next === null) {
-      this.eventTail = nodeToInsert;
-    } else {
-      content.next.prev = nodeToInsert;
-    }
-  }
-
-  insertEventLogAtPosition(position: number, nodeToInsert: EventNode) {
-    if (position === 1) {
-      this.setEventHead(nodeToInsert);
-    } else {
-      let eNode = this.eventHead;
-      let currentPosition = 1;
-      while (eNode !== null && currentPosition++ !== position)
-        eNode = eNode.next;
-      if (eNode !== null) {
-        this.insertEventLogBefore(eNode, nodeToInsert);
-      } else {
-        this.addEventLog(nodeToInsert);
-      }
-    }
-  }
-
-  removeEventLogNodesWithContent(content: EventObject) {
-    let eNode = this.eventHead;
-    while (eNode !== null) {
-      const proposedToRemove = eNode;
-      eNode = eNode.next;
-      if (this.eventLogIsDifferent(eNode.content, content))
-        this.removeEventLogNode(proposedToRemove);
-    }
-  }
-
-  removeEventLogNode(content: EventNode) {
-    if (content === this.eventHead) this.eventHead = this.eventHead.next;
-    if (content === this.eventTail) this.eventTail = this.eventTail.prev;
-    // cleanup removed EventNode pointers
-    this.removeEventNodePointers(content);
-  }
-
-  containsEventNodeWithContent(content: EventObject) {
-    if (!content) {
-      let eNode = this.eventHead;
-      while (
-        eNode !== null &&
-        !this.eventLogIsDifferent(eNode.content, content)
-      ) {
-        eNode = eNode.next;
-      }
-      return eNode === null;
-    }
-    return false;
-  }
-
-  isLogValuePrimitive(val: any): boolean {
-    return val == null || /^[sbn]/.test(typeof val);
-  }
-
-  eventLogIsDifferent(a: any, b: any): boolean {
-    return (
-      a &&
-      b &&
-      Object.keys(b).every(bKey => {
-        const bVal = b[bKey];
-        const aVal = a[bKey];
-        if (typeof bVal === 'function') {
-          return bVal(aVal);
-        }
-        return this.isLogValuePrimitive(bVal)
-          ? bVal === aVal
-          : this.eventLogIsDifferent(aVal, bVal);
-      })
-    );
-  }
-
-  isNodeTailAndHead(nodeToInsert: EventNode) {
-    return nodeToInsert === this.eventHead && nodeToInsert === this.eventTail;
-  }
-
-  removeEventNodePointers(content: EventNode) {
-    if (content.prev !== null) content.prev.next = content.next;
-    if (content.next !== null) content.next.prev = content.prev;
-    content.prev = null;
-    content.next = null;
-  }
-}
-
-export default new EventLogContainer();
+export default new EventLogContainer(new eventLogDataObject());

--- a/src/app/utils/managedlog/eventObject.ts
+++ b/src/app/utils/managedlog/eventObject.ts
@@ -10,6 +10,7 @@ export type EventStore = {
     mutationStore: Object;
     queriesStore: Object;
   };
+  cache?: Object;
 };
 
 export class EventLogContainer {
@@ -40,6 +41,12 @@ export class EventLogContainer {
     }
   }
 
+  adjustEventId(evtId, entNum) {
+    return `${evtId}.${'0'.repeat(3 - (entNum - 1).toString().length)}${(
+      entNum - 1
+    ).toString()}`;
+  }
+
   sequenceApolloLog(
     eventLog: EventStore,
     setEvents?: React.Dispatch<React.SetStateAction<{}>>,
@@ -47,7 +54,9 @@ export class EventLogContainer {
     const {
       queryManager: {mutationStore, queriesStore},
       eventId,
+      cache,
     } = eventLog;
+    let evtNum = 0;
     // perform queriesStore Check
     Object.keys(queriesStore).forEach(storeKey => {
       const proposedQry: EventNode = new EventNode({
@@ -60,9 +69,11 @@ export class EventLogContainer {
               query: queriesStore[storeKey].document.loc.source.body,
             },
           },
+          response: {},
         },
         type: 'query',
-        eventId,
+        eventId: this.adjustEventId(eventId, (evtNum += 1)),
+        cache,
       });
       if (!this.eventsBase.query[storeKey]) {
         this.logEvent(proposedQry, storeKey, setEvents);
@@ -96,9 +107,11 @@ export class EventLogContainer {
               query: mutationStore[storeKey].mutation.loc.source.body,
             },
           },
+          response: {},
         },
         type: 'mutation',
-        eventId,
+        eventId: this.adjustEventId(eventId, (evtNum += 1)),
+        cache,
       });
       if (!this.eventsBase.mutation[storeKey]) {
         this.logEvent(proposedMutate, storeKey, setEvents);

--- a/src/app/utils/managedlog/eventObject.ts
+++ b/src/app/utils/managedlog/eventObject.ts
@@ -1,0 +1,81 @@
+export interface EventBase {}
+
+export interface EventType {}
+
+export class EventNode {
+  content: EventType;
+  prev: EventNode | null;
+  next: EventNode | null;
+
+  constructor(content: EventType) {
+    this.content = content;
+    this.prev = null;
+    this.next = null;
+  }
+}
+
+export class EventLogContainer {
+  eventHead: EventNode | null;
+  eventTail: EventNode | null;
+  private eventsBase: EventBase | null;
+
+  constructor() {
+    this.eventHead = null;
+    this.eventTail = null;
+    this.eventsBase = null;
+  }
+
+  isLogValuePrimitive(val: any): boolean {
+    return val == null || /^[sbn]/.test(typeof val);
+  }
+
+  eventLogIsDifferent(a: any, b: any): boolean {
+    return (
+      a &&
+      b &&
+      Object.keys(b).every(bKey => {
+        const bVal = b[bKey];
+        const aVal = a[bKey];
+        if (typeof bVal === 'function') {
+          return bVal(aVal);
+        }
+        return this.isLogValuePrimitive(bVal)
+          ? bVal === aVal
+          : this.eventLogIsDifferent(aVal, bVal);
+      })
+    );
+  }
+
+  setEventHead(node: Node) {
+    // Write your code here.
+  }
+
+  setEventTail(node: Node) {
+    // Write your code here.
+  }
+
+  insertEventLogBefore(node: EventNode, nodeToInsert: EventNode) {
+    // Write your code here.
+  }
+
+  insertEventLogAfter(node: EventNode, nodeToInsert: EventNode) {
+    // Write your code here.
+  }
+
+  insertEventLogAtPosition(position: EventType, nodeToInsert: EventNode) {
+    // Write your code here.
+  }
+
+  removeEventLogNodesWithContent(conten: EventType) {
+    // Write your code here.
+  }
+
+  removeEventLogNode(node: EventNode) {
+    // Write your code here.
+  }
+
+  containsEventNodeWithContent(content: EventType) {
+    // Write your code here.
+    return false;
+  }
+}

--- a/src/app/utils/managedlog/lib/apollo11types.ts
+++ b/src/app/utils/managedlog/lib/apollo11types.ts
@@ -1,0 +1,30 @@
+import {DocumentNode, GraphQLError} from 'graphql';
+import {NetworkStatus} from './networkStatus';
+
+export interface MutationStoreValue {
+  mutation: DocumentNode;
+  variables?: Object;
+  loading?: boolean;
+  error?: Error | null;
+}
+
+export interface QueryStoreValue {
+  document: DocumentNode | null;
+  variables?: Record<string, any>;
+  networkStatus?: NetworkStatus;
+  networkError?: Error | null;
+  graphQLErrors?: ReadonlyArray<GraphQLError>;
+}
+
+// interface EventDesc {
+//   [k: string]: number | string | undefined | any[] | EventDesc;
+// }
+export interface EventObject {
+  // [k: string]: string | boolean | EventDesc;
+  [k: string]: QueryStoreValue | MutationStoreValue;
+}
+
+export interface EventBase {
+  mutation: EventObject[];
+  query: EventObject[];
+}

--- a/src/app/utils/managedlog/lib/apollo11types.ts
+++ b/src/app/utils/managedlog/lib/apollo11types.ts
@@ -19,14 +19,20 @@ export interface QueryStoreValue {
 // interface EventDesc {
 //   [k: string]: number | string | undefined | any[] | EventDesc;
 // }
-export interface EventObject {
-  // [k: string]: string | boolean | EventDesc;
-  [k: string]: QueryStoreValue | MutationStoreValue;
+
+// export interface EventObject {
+//   [k: string]: QueryStoreValue | MutationStoreValue;
+// }
+
+export interface EventLogObject {
+  eventId: string;
+  type: string;
+  event: QueryStoreValue | MutationStoreValue;
 }
 
 export interface EventBase {
-  mutation: {[k: string]: EventObject};
-  query: {[k: string]: EventObject};
+  mutation: {[k: string]: MutationStoreValue};
+  query: {[k: string]: QueryStoreValue};
 }
 
 // export type Record<K extends keyof any, T> = {

--- a/src/app/utils/managedlog/lib/apollo11types.ts
+++ b/src/app/utils/managedlog/lib/apollo11types.ts
@@ -6,6 +6,8 @@ export interface MutationStoreValue {
   variables?: Object;
   loading?: boolean;
   error?: Error | null;
+  request?: Record<string, any>;
+  response?: Record<string, any>;
 }
 
 export interface QueryStoreValue {
@@ -14,6 +16,8 @@ export interface QueryStoreValue {
   networkStatus?: NetworkStatus;
   networkError?: Error | null;
   graphQLErrors?: ReadonlyArray<GraphQLError>;
+  request?: Record<string, any>;
+  response?: Record<string, any>;
 }
 
 // interface EventDesc {

--- a/src/app/utils/managedlog/lib/apollo11types.ts
+++ b/src/app/utils/managedlog/lib/apollo11types.ts
@@ -36,9 +36,48 @@ export interface EventLogObject {
 }
 
 export interface EventBase {
-  mutation: {[k: string]: {mutation: MutationStoreValue; diff?: any}};
-  query: {[k: string]: {document: QueryStoreValue; diff?: any}};
+  mutation: {
+    [k: string]: {
+      mutation: MutationStoreValue;
+      diff?: any;
+      variables?: Record<string, any> | Object;
+      loading?: boolean;
+      error?: Error | null;
+    };
+  };
+  query: {
+    [k: string]: {
+      document: QueryStoreValue;
+      diff?: any;
+      variables?: Record<string, any> | Object;
+    };
+  };
 }
+
+export interface EventStore {
+  [k: string]: Record<string, any> | string;
+  lastEventId?: string;
+}
+
+let eventStore: EventStore = {
+  lastEventId: '1601084356248',
+  1601084335409: {action: {}, cache: {}, queryManager: {}},
+  1601084356248: {
+    action: {},
+    cache: {},
+    queryManager: {mutationIdCounter: 3, mutationStore: {}, queriesStore: {}},
+  },
+};
+
+const storeIdx = eventStore.lastEventId;
+
+const aStore = {
+  queryManager: (eventStore[storeIdx] as any).queryManager,
+  eventId: eventStore.lastEventId,
+  cache: (eventStore[storeIdx] as any).cache,
+};
+
+console.log('aStore :: ', aStore);
 
 // export type Record<K extends keyof any, T> = {
 //   [P in K]: T;

--- a/src/app/utils/managedlog/lib/apollo11types.ts
+++ b/src/app/utils/managedlog/lib/apollo11types.ts
@@ -25,6 +25,19 @@ export interface EventObject {
 }
 
 export interface EventBase {
-  mutation: EventObject[];
-  query: EventObject[];
+  mutation: {[k: string]: EventObject};
+  query: {[k: string]: EventObject};
 }
+
+// export type Record<K extends keyof any, T> = {
+//   [P in K]: T;
+// };
+
+// export interface ReadonlyArray<T> {
+//   /**
+//    * Determines whether an array includes a certain element, returning true or false as appropriate.
+//    * @param searchElement The element to search for.
+//    * @param fromIndex The position in this array at which to begin searching for searchElement.
+//    */
+//   includes(searchElement: T, fromIndex?: number): boolean;
+// }

--- a/src/app/utils/managedlog/lib/apollo11types.ts
+++ b/src/app/utils/managedlog/lib/apollo11types.ts
@@ -31,8 +31,8 @@ export interface EventLogObject {
 }
 
 export interface EventBase {
-  mutation: {[k: string]: MutationStoreValue};
-  query: {[k: string]: QueryStoreValue};
+  mutation: {[k: string]: {mutation: MutationStoreValue; diff?: any}};
+  query: {[k: string]: {document: QueryStoreValue; diff?: any}};
 }
 
 // export type Record<K extends keyof any, T> = {

--- a/src/app/utils/managedlog/lib/apollo11types.ts
+++ b/src/app/utils/managedlog/lib/apollo11types.ts
@@ -32,6 +32,7 @@ export interface EventLogObject {
   eventId: string;
   type: string;
   event: QueryStoreValue | MutationStoreValue;
+  cache?: Object;
 }
 
 export interface EventBase {

--- a/src/app/utils/managedlog/lib/eventLogData.ts
+++ b/src/app/utils/managedlog/lib/eventLogData.ts
@@ -1,8 +1,8 @@
 import EventNode from './eventLogNode';
-import {EventObject} from './apollo11types';
+import {EventLogObject} from './apollo11types';
 import eventLogIsDifferent from './objectDifference';
 
-export default class eventLogDataObject {
+export default class EventLogDataObject {
   eventHead: EventNode | null;
 
   eventTail: EventNode | null;
@@ -74,7 +74,7 @@ export default class eventLogDataObject {
     }
   }
 
-  removeEventLogNodesWithContent(content: EventObject) {
+  removeEventLogNodesWithContent(content: EventLogObject) {
     let eNode = this.eventHead;
     while (eNode !== null) {
       const proposedToRemove = eNode;
@@ -91,7 +91,7 @@ export default class eventLogDataObject {
     // this.removeEventNodePointers(content);
   }
 
-  containsEventNodeWithContent(content: EventObject) {
+  containsEventNodeWithContent(content: EventLogObject) {
     if (!content) {
       let eNode = this.eventHead;
       while (eNode !== null && !eventLogIsDifferent(eNode.content, content)) {

--- a/src/app/utils/managedlog/lib/eventLogData.ts
+++ b/src/app/utils/managedlog/lib/eventLogData.ts
@@ -111,17 +111,18 @@ export default class EventLogDataObject {
   }
 
   append(targetObj: EventLogDataObject) {
+    const tgtObject = targetObj;
     if (this.eventHead === null) {
-      if (targetObj && targetObj.eventHead) {
-        this.eventHead = targetObj.eventHead;
+      if (tgtObject && tgtObject.eventHead) {
+        this.eventHead = tgtObject.eventHead;
       }
-      if (targetObj && targetObj.eventTail) {
-        this.eventTail = targetObj.eventTail;
+      if (tgtObject && tgtObject.eventTail) {
+        this.eventTail = tgtObject.eventTail;
       }
-    } else if (this.eventHead && targetObj.eventHead) {
-      targetObj.eventHead.prev = this.eventTail;
-      this.eventTail.next = targetObj.eventHead;
-      this.eventTail = targetObj.eventHead;
+    } else if (this.eventHead && tgtObject.eventHead) {
+      tgtObject.eventHead.prev = this.eventTail;
+      this.eventTail.next = tgtObject.eventHead;
+      this.eventTail = tgtObject.eventHead;
     }
     this.eventLength += targetObj.eventLength;
   }
@@ -130,23 +131,22 @@ export default class EventLogDataObject {
     if (this.eventHead === null && this.eventTail === null) {
       console.log('Empty EventLog Object');
       return false;
-    } else {
-      // console.log('PRINTING NODES ');
-      let ii = 0;
-      let temp = this.eventHead;
-      while (temp !== null) {
-        process.stdout.write(String(temp.content.eventId));
-        process.stdout.write(' <-> ');
-        // console.log('NODE ', temp);
-        temp = temp.next;
-        ii += 1;
-        if (ii === 10) {
-          temp = null;
-        }
-      }
-      // console.log('null');
-      return true;
     }
+    // console.log('PRINTING NODES ');
+    let ii = 0;
+    let temp = this.eventHead;
+    while (temp !== null) {
+      process.stdout.write(String(temp.content.eventId));
+      process.stdout.write(' <-> ');
+      // console.log('NODE ', temp);
+      temp = temp.next;
+      ii += 1;
+      if (ii === 10) {
+        temp = null;
+      }
+    }
+    // console.log('null');
+    return true;
   }
 
   isNodeTailAndHead(nodeToInsert: EventNode) {

--- a/src/app/utils/managedlog/lib/eventLogData.ts
+++ b/src/app/utils/managedlog/lib/eventLogData.ts
@@ -1,0 +1,115 @@
+import EventNode from './eventLogNode';
+import {EventObject} from './apollo11types';
+import eventLogIsDifferent from './objectDifference';
+
+export default class eventLogDataObject {
+  eventHead: EventNode | null;
+
+  eventTail: EventNode | null;
+
+  constructor() {
+    this.eventHead = null;
+    this.eventTail = null;
+  }
+
+  setEventHead(content: EventNode) {
+    if (this.eventHead === null) {
+      this.eventHead = content;
+      this.eventTail = content;
+    } else {
+      this.insertEventLogBefore(this.eventHead, content);
+    }
+  }
+
+  addEventLog(content: EventNode) {
+    if (this.eventTail === null) {
+      this.setEventHead(content);
+    } else {
+      this.insertEventLogAfter(this.eventTail, content);
+    }
+  }
+
+  insertEventLogBefore(content: EventNode, nodeToInsert: EventNode) {
+    if (this.isNodeTailAndHead(nodeToInsert)) return;
+    const [insertContent, insertNode] = [content, nodeToInsert]; // make a copy of mutable argument
+    this.removeEventLogNode(insertContent);
+    insertNode.prev = insertContent.prev;
+    insertNode.next = insertContent;
+    if (insertContent.prev === null) {
+      this.eventHead = insertNode;
+    } else {
+      insertContent.prev.next = insertNode;
+    }
+    insertContent.prev = insertNode;
+  }
+
+  insertEventLogAfter(content: EventNode, nodeToInsert: EventNode) {
+    if (this.isNodeTailAndHead(nodeToInsert)) return;
+    const [insertContent, insertNode] = [content, nodeToInsert]; // make a copy of mutable argument
+    this.removeEventLogNode(insertContent);
+    insertNode.prev = insertContent;
+    insertNode.next = insertContent.next;
+    if (insertContent.next === null) {
+      this.eventTail = insertNode;
+    } else {
+      insertContent.next.prev = insertNode;
+    }
+  }
+
+  insertEventLogAtPosition(position: number, nodeToInsert: EventNode) {
+    if (position === 1) {
+      this.setEventHead(nodeToInsert);
+    } else {
+      let eNode = this.eventHead;
+      let currentPosition = 1;
+      while (eNode !== null && currentPosition !== position) {
+        eNode = eNode.next;
+        currentPosition += 1;
+      }
+      if (eNode !== null) {
+        this.insertEventLogBefore(eNode, nodeToInsert);
+      } else {
+        this.addEventLog(nodeToInsert);
+      }
+    }
+  }
+
+  removeEventLogNodesWithContent(content: EventObject) {
+    let eNode = this.eventHead;
+    while (eNode !== null) {
+      const proposedToRemove = eNode;
+      eNode = eNode.next;
+      if (eventLogIsDifferent(eNode.content, content))
+        this.removeEventLogNode(proposedToRemove);
+    }
+  }
+
+  removeEventLogNode(content: EventNode) {
+    if (content === this.eventHead) this.eventHead = this.eventHead.next;
+    if (content === this.eventTail) this.eventTail = this.eventTail.prev;
+    // cleanup removed EventNode pointers
+    // this.removeEventNodePointers(content);
+  }
+
+  containsEventNodeWithContent(content: EventObject) {
+    if (!content) {
+      let eNode = this.eventHead;
+      while (eNode !== null && !eventLogIsDifferent(eNode.content, content)) {
+        eNode = eNode.next;
+      }
+      return eNode === null;
+    }
+    return false;
+  }
+
+  isNodeTailAndHead(nodeToInsert: EventNode) {
+    return nodeToInsert === this.eventHead && nodeToInsert === this.eventTail;
+  }
+
+  // removeEventNodePointers(content: EventNode) {
+  //   if (content.prev !== null) content.prev.next = content.next;
+  //   if (content.next !== null) content.next.prev = content.prev;
+  //   content.prev = null;
+  //   content.next = null;
+  // }
+}

--- a/src/app/utils/managedlog/lib/eventLogData.ts
+++ b/src/app/utils/managedlog/lib/eventLogData.ts
@@ -1,6 +1,6 @@
 import EventNode from './eventLogNode';
 import {EventLogObject} from './apollo11types';
-import eventLogIsDifferent from './objectDifference';
+// import eventLogIsDifferent from './objectDifference';
 
 export default class EventLogDataObject {
   eventHead: EventNode | null;
@@ -22,17 +22,19 @@ export default class EventLogDataObject {
   }
 
   addEventLog(content: EventNode) {
-    if (this.eventTail === null) {
+    if (this.eventHead === null) {
       this.setEventHead(content);
     } else {
-      this.insertEventLogAfter(this.eventTail, content);
+      content.prev = this.eventTail;
+      this.eventTail.next = content;
+      this.eventTail = content;
+      // this.insertEventLogAfter(this.eventTail, content);
     }
   }
 
   insertEventLogBefore(content: EventNode, nodeToInsert: EventNode) {
     if (this.isNodeTailAndHead(nodeToInsert)) return;
     const [insertContent, insertNode] = [content, nodeToInsert]; // make a copy of mutable argument
-    this.removeEventLogNode(insertContent);
     insertNode.prev = insertContent.prev;
     insertNode.next = insertContent;
     if (insertContent.prev === null) {
@@ -46,70 +48,70 @@ export default class EventLogDataObject {
   insertEventLogAfter(content: EventNode, nodeToInsert: EventNode) {
     if (this.isNodeTailAndHead(nodeToInsert)) return;
     const [insertContent, insertNode] = [content, nodeToInsert]; // make a copy of mutable argument
-    this.removeEventLogNode(insertContent);
     insertNode.prev = insertContent;
     insertNode.next = insertContent.next;
     if (insertContent.next === null) {
+      insertContent.next = insertNode;
       this.eventTail = insertNode;
     } else {
-      insertContent.next.prev = insertNode;
+      insertContent.next = insertNode;
     }
   }
 
-  insertEventLogAtPosition(position: number, nodeToInsert: EventNode) {
-    if (position === 1) {
-      this.setEventHead(nodeToInsert);
-    } else {
-      let eNode = this.eventHead;
-      let currentPosition = 1;
-      while (eNode !== null && currentPosition !== position) {
-        eNode = eNode.next;
-        currentPosition += 1;
-      }
-      if (eNode !== null) {
-        this.insertEventLogBefore(eNode, nodeToInsert);
-      } else {
-        this.addEventLog(nodeToInsert);
-      }
-    }
-  }
+  // insertEventLogAtPosition(position: number, nodeToInsert: EventNode) {
+  //   if (position === 1) {
+  //     this.setEventHead(nodeToInsert);
+  //   } else {
+  //     let eNode = this.eventHead;
+  //     let currentPosition = 1;
+  //     while (eNode !== null && currentPosition !== position) {
+  //       eNode = eNode.next;
+  //       currentPosition += 1;
+  //     }
+  //     if (eNode !== null) {
+  //       this.insertEventLogBefore(eNode, nodeToInsert);
+  //     } else {
+  //       this.addEventLog(nodeToInsert);
+  //     }
+  //   }
+  // }
 
-  removeEventLogNodesWithContent(content: EventLogObject) {
-    let eNode = this.eventHead;
-    while (eNode !== null) {
-      const proposedToRemove = eNode;
-      eNode = eNode.next;
-      if (eventLogIsDifferent(eNode.content, content))
-        this.removeEventLogNode(proposedToRemove);
-    }
-  }
+  // removeEventLogNodesWithContent(content: EventLogObject) {
+  //   let eNode = this.eventHead;
+  //   while (eNode !== null) {
+  //     const proposedToRemove = eNode;
+  //     eNode = eNode.next;
+  //     if (eventLogIsDifferent(eNode.content, content))
+  //       this.removeEventLogNode(proposedToRemove);
+  //   }
+  // }
 
   removeEventLogNode(content: EventNode) {
     if (content === this.eventHead) this.eventHead = this.eventHead.next;
     if (content === this.eventTail) this.eventTail = this.eventTail.prev;
     // cleanup removed EventNode pointers
-    // this.removeEventNodePointers(content);
+    this.removeEventNodePointers(content);
   }
 
-  containsEventNodeWithContent(content: EventLogObject) {
-    if (!content) {
-      let eNode = this.eventHead;
-      while (eNode !== null && !eventLogIsDifferent(eNode.content, content)) {
-        eNode = eNode.next;
-      }
-      return eNode === null;
-    }
-    return false;
-  }
+  // containsEventNodeWithContent(content: EventLogObject) {
+  //   if (!content) {
+  //     let eNode = this.eventHead;
+  //     while (eNode !== null && !eventLogIsDifferent(eNode.content, content)) {
+  //       eNode = eNode.next;
+  //     }
+  //     return eNode === null;
+  //   }
+  //   return false;
+  // }
 
   isNodeTailAndHead(nodeToInsert: EventNode) {
     return nodeToInsert === this.eventHead && nodeToInsert === this.eventTail;
   }
 
-  // removeEventNodePointers(content: EventNode) {
-  //   if (content.prev !== null) content.prev.next = content.next;
-  //   if (content.next !== null) content.next.prev = content.prev;
-  //   content.prev = null;
-  //   content.next = null;
-  // }
+  removeEventNodePointers(content: EventNode) {
+    if (content.prev !== null) content.prev.next = content.next;
+    if (content.next !== null) content.next.prev = content.prev;
+    content.prev = null;
+    content.next = null;
+  }
 }

--- a/src/app/utils/managedlog/lib/eventLogData.ts
+++ b/src/app/utils/managedlog/lib/eventLogData.ts
@@ -95,12 +95,7 @@ export default class EventLogDataObject {
     if (content === this.eventHead) this.eventHead = this.eventHead.next;
     if (content === this.eventTail) this.eventTail = this.eventTail.prev;
     // cleanup removed EventNode pointers
-    // this.removeEventNodePointers(content);
-    const removeNode = content;
-    if (removeNode.prev !== null) removeNode.prev.next = removeNode.next;
-    if (removeNode.next !== null) removeNode.next.prev = removeNode.prev;
-    removeNode.prev = null;
-    removeNode.next = null;
+    this.removeEventNodePointers(content);
     this.eventLength -= 1;
   }
 
@@ -115,17 +110,58 @@ export default class EventLogDataObject {
     return false;
   }
 
+  append(targetObj: EventLogDataObject) {
+    if (this.eventHead === null) {
+      if (targetObj && targetObj.eventHead) {
+        this.eventHead = targetObj.eventHead;
+      }
+      if (targetObj && targetObj.eventTail) {
+        this.eventTail = targetObj.eventTail;
+      }
+    } else if (this.eventHead && targetObj.eventHead) {
+      targetObj.eventHead.prev = this.eventTail;
+      this.eventTail.next = targetObj.eventHead;
+      this.eventTail = targetObj.eventHead;
+    }
+    this.eventLength += targetObj.eventLength;
+  }
+
+  debugPrint(): boolean {
+    if (this.eventHead === null && this.eventTail === null) {
+      console.log('Empty EventLog Object');
+      return false;
+    } else {
+      // console.log('PRINTING NODES ');
+      let ii = 0;
+      let temp = this.eventHead;
+      while (temp !== null) {
+        process.stdout.write(String(temp.content.eventId));
+        process.stdout.write(' <-> ');
+        // console.log('NODE ', temp);
+        temp = temp.next;
+        ii += 1;
+        if (ii === 10) {
+          temp = null;
+        }
+      }
+      // console.log('null');
+      return true;
+    }
+  }
+
   isNodeTailAndHead(nodeToInsert: EventNode) {
     return nodeToInsert === this.eventHead && nodeToInsert === this.eventTail;
   }
 
-  // removeEventNodePointers(content: EventNode) {
-  //   const removeNode = content;
-  //   if (removeNode.prev !== null) removeNode.prev.next = removeNode.next;
-  //   if (removeNode.next !== null) removeNode.next.prev = removeNode.prev;
-  //   removeNode.prev = null;
-  //   removeNode.next = null;
-  // }
+  removeEventNodePointers(content: EventNode) {
+    const removeNode = content;
+    if (removeNode.prev !== null) removeNode.prev.next = removeNode.next;
+    if (removeNode.next !== null) removeNode.next.prev = removeNode.prev;
+    removeNode.prev = null;
+    removeNode.next = null;
+    // line to shut linter
+    console.debug(this.eventLength);
+  }
 
   map(decorator): any[] {
     const _extractList = [];

--- a/src/app/utils/managedlog/lib/eventLogData.ts
+++ b/src/app/utils/managedlog/lib/eventLogData.ts
@@ -130,3 +130,12 @@ export default class EventLogDataObject {
     return _extractList;
   }
 }
+
+export type EventLogProps = {
+  eventLog: EventLogDataObject;
+  handleEventChange: any;
+};
+
+export type ApolloTabProps = {
+  eventLog: EventLogDataObject;
+};

--- a/src/app/utils/managedlog/lib/eventLogData.ts
+++ b/src/app/utils/managedlog/lib/eventLogData.ts
@@ -31,6 +31,7 @@ export default class EventLogDataObject {
       this.insertEventLogAfter(this.eventTail, content);
     }
     this.eventLength += 1;
+    // return this;
   }
 
   insertEventLogBefore(content: EventNode, nodeToInsert: EventNode) {
@@ -57,6 +58,7 @@ export default class EventLogDataObject {
     } else {
       insertContent.next = insertNode;
     }
+    // return this;
   }
 
   insertEventLogAtPosition(position: number, nodeToInsert: EventNode) {
@@ -93,7 +95,12 @@ export default class EventLogDataObject {
     if (content === this.eventHead) this.eventHead = this.eventHead.next;
     if (content === this.eventTail) this.eventTail = this.eventTail.prev;
     // cleanup removed EventNode pointers
-    this.removeEventNodePointers(content);
+    // this.removeEventNodePointers(content);
+    const removeNode = content;
+    if (removeNode.prev !== null) removeNode.prev.next = removeNode.next;
+    if (removeNode.next !== null) removeNode.next.prev = removeNode.prev;
+    removeNode.prev = null;
+    removeNode.next = null;
     this.eventLength -= 1;
   }
 
@@ -112,13 +119,13 @@ export default class EventLogDataObject {
     return nodeToInsert === this.eventHead && nodeToInsert === this.eventTail;
   }
 
-  removeEventNodePointers(content: EventNode) {
-    const removeNode = content;
-    if (removeNode.prev !== null) removeNode.prev.next = removeNode.next;
-    if (removeNode.next !== null) removeNode.next.prev = removeNode.prev;
-    removeNode.prev = null;
-    removeNode.next = null;
-  }
+  // removeEventNodePointers(content: EventNode) {
+  //   const removeNode = content;
+  //   if (removeNode.prev !== null) removeNode.prev.next = removeNode.next;
+  //   if (removeNode.next !== null) removeNode.next.prev = removeNode.prev;
+  //   removeNode.prev = null;
+  //   removeNode.next = null;
+  // }
 
   map(decorator): any[] {
     const _extractList = [];

--- a/src/app/utils/managedlog/lib/eventLogData.ts
+++ b/src/app/utils/managedlog/lib/eventLogData.ts
@@ -1,15 +1,18 @@
 import EventNode from './eventLogNode';
 import {EventLogObject} from './apollo11types';
-// import eventLogIsDifferent from './objectDifference';
+import eventLogIsDifferent from './objectDifference';
 
 export default class EventLogDataObject {
   eventHead: EventNode | null;
 
   eventTail: EventNode | null;
 
+  eventLength: number;
+
   constructor() {
     this.eventHead = null;
     this.eventTail = null;
+    this.eventLength = 0;
   }
 
   setEventHead(content: EventNode) {
@@ -25,11 +28,9 @@ export default class EventLogDataObject {
     if (this.eventHead === null) {
       this.setEventHead(content);
     } else {
-      content.prev = this.eventTail;
-      this.eventTail.next = content;
-      this.eventTail = content;
-      // this.insertEventLogAfter(this.eventTail, content);
+      this.insertEventLogAfter(this.eventTail, content);
     }
+    this.eventLength++;
   }
 
   insertEventLogBefore(content: EventNode, nodeToInsert: EventNode) {
@@ -58,51 +59,54 @@ export default class EventLogDataObject {
     }
   }
 
-  // insertEventLogAtPosition(position: number, nodeToInsert: EventNode) {
-  //   if (position === 1) {
-  //     this.setEventHead(nodeToInsert);
-  //   } else {
-  //     let eNode = this.eventHead;
-  //     let currentPosition = 1;
-  //     while (eNode !== null && currentPosition !== position) {
-  //       eNode = eNode.next;
-  //       currentPosition += 1;
-  //     }
-  //     if (eNode !== null) {
-  //       this.insertEventLogBefore(eNode, nodeToInsert);
-  //     } else {
-  //       this.addEventLog(nodeToInsert);
-  //     }
-  //   }
-  // }
+  insertEventLogAtPosition(position: number, nodeToInsert: EventNode) {
+    if (position === 1) {
+      this.setEventHead(nodeToInsert);
+      this.eventLength++;
+    } else {
+      let eNode = this.eventHead;
+      let currentPosition = 1;
+      while (eNode !== null && currentPosition !== position) {
+        eNode = eNode.next;
+        currentPosition += 1;
+      }
+      if (eNode !== null) {
+        this.insertEventLogBefore(eNode, nodeToInsert);
+        this.eventLength++;
+      } else {
+        this.addEventLog(nodeToInsert);
+      }
+    }
+  }
 
-  // removeEventLogNodesWithContent(content: EventLogObject) {
-  //   let eNode = this.eventHead;
-  //   while (eNode !== null) {
-  //     const proposedToRemove = eNode;
-  //     eNode = eNode.next;
-  //     if (eventLogIsDifferent(eNode.content, content))
-  //       this.removeEventLogNode(proposedToRemove);
-  //   }
-  // }
+  removeEventLogNodesWithContent(content: EventLogObject) {
+    let eNode = this.eventHead;
+    while (eNode !== null) {
+      const proposedToRemove = eNode;
+      eNode = eNode.next;
+      if (eventLogIsDifferent(eNode.content, content))
+        this.removeEventLogNode(proposedToRemove);
+    }
+  }
 
   removeEventLogNode(content: EventNode) {
     if (content === this.eventHead) this.eventHead = this.eventHead.next;
     if (content === this.eventTail) this.eventTail = this.eventTail.prev;
     // cleanup removed EventNode pointers
     this.removeEventNodePointers(content);
+    this.eventLength--;
   }
 
-  // containsEventNodeWithContent(content: EventLogObject) {
-  //   if (!content) {
-  //     let eNode = this.eventHead;
-  //     while (eNode !== null && !eventLogIsDifferent(eNode.content, content)) {
-  //       eNode = eNode.next;
-  //     }
-  //     return eNode === null;
-  //   }
-  //   return false;
-  // }
+  containsEventNodeWithContent(content: EventLogObject) {
+    if (!content) {
+      let eNode = this.eventHead;
+      while (eNode !== null && !eventLogIsDifferent(eNode.content, content)) {
+        eNode = eNode.next;
+      }
+      return eNode === null;
+    }
+    return false;
+  }
 
   isNodeTailAndHead(nodeToInsert: EventNode) {
     return nodeToInsert === this.eventHead && nodeToInsert === this.eventTail;
@@ -113,5 +117,15 @@ export default class EventLogDataObject {
     if (content.next !== null) content.next.prev = content.prev;
     content.prev = null;
     content.next = null;
+  }
+
+  map(decorator): any[] {
+    const _extractList = [];
+    let curr = this.eventHead;
+    while (curr) {
+      _extractList.push(decorator(curr));
+      curr = curr.next;
+    }
+    return _extractList;
   }
 }

--- a/src/app/utils/managedlog/lib/eventLogData.ts
+++ b/src/app/utils/managedlog/lib/eventLogData.ts
@@ -30,7 +30,7 @@ export default class EventLogDataObject {
     } else {
       this.insertEventLogAfter(this.eventTail, content);
     }
-    this.eventLength++;
+    this.eventLength += 1;
   }
 
   insertEventLogBefore(content: EventNode, nodeToInsert: EventNode) {
@@ -62,7 +62,7 @@ export default class EventLogDataObject {
   insertEventLogAtPosition(position: number, nodeToInsert: EventNode) {
     if (position === 1) {
       this.setEventHead(nodeToInsert);
-      this.eventLength++;
+      this.eventLength += 1;
     } else {
       let eNode = this.eventHead;
       let currentPosition = 1;
@@ -72,7 +72,7 @@ export default class EventLogDataObject {
       }
       if (eNode !== null) {
         this.insertEventLogBefore(eNode, nodeToInsert);
-        this.eventLength++;
+        this.eventLength += 1;
       } else {
         this.addEventLog(nodeToInsert);
       }
@@ -94,7 +94,7 @@ export default class EventLogDataObject {
     if (content === this.eventTail) this.eventTail = this.eventTail.prev;
     // cleanup removed EventNode pointers
     this.removeEventNodePointers(content);
-    this.eventLength--;
+    this.eventLength -= 1;
   }
 
   containsEventNodeWithContent(content: EventLogObject) {
@@ -113,10 +113,11 @@ export default class EventLogDataObject {
   }
 
   removeEventNodePointers(content: EventNode) {
-    if (content.prev !== null) content.prev.next = content.next;
-    if (content.next !== null) content.next.prev = content.prev;
-    content.prev = null;
-    content.next = null;
+    const removeNode = content;
+    if (removeNode.prev !== null) removeNode.prev.next = removeNode.next;
+    if (removeNode.next !== null) removeNode.next.prev = removeNode.prev;
+    removeNode.prev = null;
+    removeNode.next = null;
   }
 
   map(decorator): any[] {

--- a/src/app/utils/managedlog/lib/eventLogNode.ts
+++ b/src/app/utils/managedlog/lib/eventLogNode.ts
@@ -13,3 +13,19 @@ export default class EventNode {
     this.next = null;
   }
 }
+
+export type EventDetailsProps = {
+  activeEvent?: EventNode;
+};
+
+export type CacheProps = {
+  activeEvent?: EventNode;
+  toggleCacheDetails: any;
+  handleCacheChange: any;
+  cacheDetailsVisible: boolean;
+};
+
+export type CacheDetailsProps = {
+  activeEvent?: EventNode;
+  activeCache: any;
+};

--- a/src/app/utils/managedlog/lib/eventLogNode.ts
+++ b/src/app/utils/managedlog/lib/eventLogNode.ts
@@ -1,13 +1,13 @@
-import {EventObject} from './apollo11types';
+import {EventLogObject} from './apollo11types';
 
 export default class EventNode {
-  content: EventObject;
+  content: EventLogObject;
 
   prev: EventNode | null;
 
   next: EventNode | null;
 
-  constructor(content: EventObject) {
+  constructor(content: EventLogObject) {
     this.content = content;
     this.prev = null;
     this.next = null;

--- a/src/app/utils/managedlog/lib/eventLogNode.ts
+++ b/src/app/utils/managedlog/lib/eventLogNode.ts
@@ -1,0 +1,15 @@
+import {EventObject} from './apollo11types';
+
+export default class EventNode {
+  content: EventObject;
+
+  prev: EventNode | null;
+
+  next: EventNode | null;
+
+  constructor(content: EventObject) {
+    this.content = content;
+    this.prev = null;
+    this.next = null;
+  }
+}

--- a/src/app/utils/managedlog/lib/networkStatus.ts
+++ b/src/app/utils/managedlog/lib/networkStatus.ts
@@ -1,0 +1,56 @@
+/**
+ * The current status of a query’s execution in our system.
+ */
+export enum NetworkStatus {
+  /**
+   * The query has never been run before and the query is now currently running. A query will still
+   * have this network status even if a partial data result was returned from the cache, but a
+   * query was dispatched anyway.
+   */
+  loading = 1,
+
+  /**
+   * If `setVariables` was called and a query was fired because of that then the network status
+   * will be `setVariables` until the result of that query comes back.
+   */
+  setVariables = 2,
+
+  /**
+   * Indicates that `fetchMore` was called on this query and that the query created is currently in
+   * flight.
+   */
+  fetchMore = 3,
+
+  /**
+   * Similar to the `setVariables` network status. It means that `refetch` was called on a query
+   * and the refetch request is currently in flight.
+   */
+  refetch = 4,
+
+  /**
+   * Indicates that a polling query is currently in flight. So for example if you are polling a
+   * query every 10 seconds then the network status will switch to `poll` every 10 seconds whenever
+   * a poll request has been sent but not resolved.
+   */
+  poll = 6,
+
+  /**
+   * No request is in flight for this query, and no errors happened. Everything is OK.
+   */
+  ready = 7,
+
+  /**
+   * No request is in flight for this query, but one or more errors were detected.
+   */
+  error = 8,
+}
+
+/**
+ * Returns true if there is currently a network request in flight according to a given network
+ * status.
+ */
+export function isNetworkRequestInFlight(
+  networkStatus?: NetworkStatus,
+): boolean {
+  return networkStatus ? networkStatus < 7 : false;
+}

--- a/src/app/utils/managedlog/lib/networkStatus.ts
+++ b/src/app/utils/managedlog/lib/networkStatus.ts
@@ -7,42 +7,42 @@ export enum NetworkStatus {
    * have this network status even if a partial data result was returned from the cache, but a
    * query was dispatched anyway.
    */
-  loading = 1,
+  Loading = 1,
 
   /**
    * If `setVariables` was called and a query was fired because of that then the network status
    * will be `setVariables` until the result of that query comes back.
    */
-  setVariables = 2,
+  SetVariables = 2,
 
   /**
    * Indicates that `fetchMore` was called on this query and that the query created is currently in
    * flight.
    */
-  fetchMore = 3,
+  FetchMore = 3,
 
   /**
    * Similar to the `setVariables` network status. It means that `refetch` was called on a query
    * and the refetch request is currently in flight.
    */
-  refetch = 4,
+  Refetch = 4,
 
   /**
    * Indicates that a polling query is currently in flight. So for example if you are polling a
    * query every 10 seconds then the network status will switch to `poll` every 10 seconds whenever
    * a poll request has been sent but not resolved.
    */
-  poll = 6,
+  Poll = 6,
 
   /**
    * No request is in flight for this query, and no errors happened. Everything is OK.
    */
-  ready = 7,
+  Ready = 7,
 
   /**
    * No request is in flight for this query, but one or more errors were detected.
    */
-  error = 8,
+  Error = 8,
 }
 
 /**

--- a/src/app/utils/managedlog/lib/objectDifference.ts
+++ b/src/app/utils/managedlog/lib/objectDifference.ts
@@ -5,21 +5,24 @@ const isLogValuePrimitive = (val: any): boolean => {
 };
 
 const eventLogIsDifferent = (a: any, b: any): boolean => {
-  return equal(a, b);
-  // return (
-  //   a &&
-  //   b &&
-  //   Object.keys(b).every(bKey => {
-  //     const bVal = b[bKey];
-  //     const aVal = a[bKey];
-  //     if (typeof bVal === 'function') {
-  //       return bVal(aVal);
-  //     }
-  //     return isLogValuePrimitive(bVal)
-  //       ? bVal === aVal
-  //       : eventLogIsDifferent(aVal, bVal);
-  //   })
-  // );
+  // console.log('COMPARING ......');
+  // console.log('A => ', a);
+  // console.log('B => ', b);
+  // return equal(a, b);
+  return (
+    a &&
+    b &&
+    Object.keys(b).every(bKey => {
+      const bVal = b[bKey];
+      const aVal = a[bKey];
+      if (typeof bVal === 'function') {
+        return bVal(aVal);
+      }
+      return isLogValuePrimitive(bVal)
+        ? bVal === aVal
+        : eventLogIsDifferent(aVal, bVal);
+    })
+  );
 };
 
 export default eventLogIsDifferent;

--- a/src/app/utils/managedlog/lib/objectDifference.ts
+++ b/src/app/utils/managedlog/lib/objectDifference.ts
@@ -2,7 +2,7 @@ const isLogValuePrimitive = (val: any): boolean => {
   return val == null || /^[sbn]/.test(typeof val);
 };
 
-export const eventLogIsDifferent = (a: any, b: any): boolean => {
+const eventLogIsDifferent = (a: any, b: any): boolean => {
   return (
     a &&
     b &&
@@ -18,3 +18,5 @@ export const eventLogIsDifferent = (a: any, b: any): boolean => {
     })
   );
 };
+
+export default eventLogIsDifferent;

--- a/src/app/utils/managedlog/lib/objectDifference.ts
+++ b/src/app/utils/managedlog/lib/objectDifference.ts
@@ -1,13 +1,10 @@
-import {equal} from '@wry/equality';
+// import {equal} from '@wry/equality';
 
 const isLogValuePrimitive = (val: any): boolean => {
   return val == null || /^[sbn]/.test(typeof val);
 };
 
 const eventLogIsDifferent = (a: any, b: any): boolean => {
-  // console.log('COMPARING ......');
-  // console.log('A => ', a);
-  // console.log('B => ', b);
   // return equal(a, b);
   return (
     a &&

--- a/src/app/utils/managedlog/lib/objectDifference.ts
+++ b/src/app/utils/managedlog/lib/objectDifference.ts
@@ -1,0 +1,20 @@
+const isLogValuePrimitive = (val: any): boolean => {
+  return val == null || /^[sbn]/.test(typeof val);
+};
+
+export const eventLogIsDifferent = (a: any, b: any): boolean => {
+  return (
+    a &&
+    b &&
+    Object.keys(b).every(bKey => {
+      const bVal = b[bKey];
+      const aVal = a[bKey];
+      if (typeof bVal === 'function') {
+        return bVal(aVal);
+      }
+      return isLogValuePrimitive(bVal)
+        ? bVal === aVal
+        : eventLogIsDifferent(aVal, bVal);
+    })
+  );
+};

--- a/src/app/utils/managedlog/lib/objectDifference.ts
+++ b/src/app/utils/managedlog/lib/objectDifference.ts
@@ -1,22 +1,25 @@
+import {equal} from '@wry/equality';
+
 const isLogValuePrimitive = (val: any): boolean => {
   return val == null || /^[sbn]/.test(typeof val);
 };
 
 const eventLogIsDifferent = (a: any, b: any): boolean => {
-  return (
-    a &&
-    b &&
-    Object.keys(b).every(bKey => {
-      const bVal = b[bKey];
-      const aVal = a[bKey];
-      if (typeof bVal === 'function') {
-        return bVal(aVal);
-      }
-      return isLogValuePrimitive(bVal)
-        ? bVal === aVal
-        : eventLogIsDifferent(aVal, bVal);
-    })
-  );
+  return equal(a, b);
+  // return (
+  //   a &&
+  //   b &&
+  //   Object.keys(b).every(bKey => {
+  //     const bVal = b[bKey];
+  //     const aVal = a[bKey];
+  //     if (typeof bVal === 'function') {
+  //       return bVal(aVal);
+  //     }
+  //     return isLogValuePrimitive(bVal)
+  //       ? bVal === aVal
+  //       : eventLogIsDifferent(aVal, bVal);
+  //   })
+  // );
 };
 
 export default eventLogIsDifferent;

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -124,7 +124,10 @@ export default function createURICacheEventListener(
         newEvents.lastEventId = eventId;
 
         // console.log('newEvents :>> ', newEvents);
-        eventList.sequenceApolloLog({queryManager, eventId}, setEvents);
+        eventList.sequenceApolloLog(
+          {queryManager, eventId, cache: request.cache},
+          setEvents,
+        );
         return newEvents;
       });
     }

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -67,6 +67,7 @@ export default function createURICacheEventListener(
 
         newEvents[eventId] = {...prevEvents[eventId], ...event};
         newEvents[eventId].cache = request.apolloCache;
+        newEvents[eventId].queryManager = request.queryManager;
         // newEvents.queryIdCounter = request.queryIdCounter;
         // newEvents.mutationIdCounter = request.mutationIdCounter;
         // newEvents.requestIdCounter = request.requestIdCounter;
@@ -77,6 +78,16 @@ export default function createURICacheEventListener(
           tabId,
           'createURICacheEventListener setEvent :>>',
           newEvents,
+        );
+
+        console.log('newEvents :>> ', newEvents);
+        eventList.sequenceApolloLog(
+          {
+            queryManager: request.queryManager,
+            eventId,
+            cache: request.apolloCache,
+          },
+          setEvents,
         );
 
         return newEvents;
@@ -123,7 +134,7 @@ export default function createURICacheEventListener(
         newEvents[eventId].queryManager = queryManager;
         newEvents.lastEventId = eventId;
 
-        // console.log('newEvents :>> ', newEvents);
+        console.log('newEvents :>> ', newEvents);
         eventList.sequenceApolloLog(
           {queryManager, eventId, cache: request.cache},
           setEvents,

--- a/src/app/utils/messaging.ts
+++ b/src/app/utils/messaging.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import {EventLogContainer} from './managedlog/eventObject';
 
 // Listen for messages from the contentScript
 // The contentScript will send to the App:
@@ -7,6 +8,8 @@ import React from 'react';
 export default function createURICacheEventListener(
   setApolloURI: React.Dispatch<React.SetStateAction<string>>,
   setStores: React.Dispatch<React.SetStateAction<{}>>,
+  eventList: EventLogContainer,
+  setEvents: React.Dispatch<React.SetStateAction<{}>>,
 ) {
   chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     const {tabId} = chrome.devtools.inspectedWindow;
@@ -121,7 +124,7 @@ export default function createURICacheEventListener(
         newEvents.lastEventId = eventId;
 
         // console.log('newEvents :>> ', newEvents);
-
+        eventList.sequenceApolloLog({queryManager, eventId}, setEvents);
         return newEvents;
       });
     }

--- a/src/extension/contentScript.ts
+++ b/src/extension/contentScript.ts
@@ -58,6 +58,7 @@ window.addEventListener(
         queryIdCounter: event.data.queryIdCounter,
         mutationIdCounter: event.data.mutationIdCounter,
         requestIdCounter: event.data.requestIdCounter,
+        queryManager: event.data.queryManager,
       };
 
       console.log(

--- a/src/hook/apollo.ts
+++ b/src/hook/apollo.ts
@@ -82,7 +82,7 @@ function apollo11Callback(
 
 (function hooked(win: any) {
   // eslint-disable-next-line no-undef
-  let detectionInterval: NodeJS.Timeout;
+  let detectionInterval: NodeJS.Timeout; // number; //
 
   const findApolloClient = () => {
     if (
@@ -116,5 +116,5 @@ function apollo11Callback(
       );
     }
   };
-  detectionInterval = setInterval(findApolloClient, 1000);
+  detectionInterval = global.setInterval(findApolloClient, 1000);
 })(window);

--- a/src/hook/apollo.ts
+++ b/src/hook/apollo.ts
@@ -82,7 +82,7 @@ function apollo11Callback(
 
 (function hooked(win: any) {
   // eslint-disable-next-line no-undef
-  let detectionInterval: NodeJS.Timeout; // number; //
+  let detectionInterval: NodeJS.Timeout;
 
   const findApolloClient = () => {
     if (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "allowJs": true,
     "jsx": "react",
     "target": "esnext",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "lib": ["es2015", "esnext.asynciterable", "dom"]
   },
   "include": ["./src/app/**/*", "./index.d.ts", "./src/custom.d.ts"],
   "exclude": ["node_modules", ".vscode", "__tests__"]


### PR DESCRIPTION
# NOTES ABOUT THIS PR:
In this PR,

1.  You may need to familiarize yourself with the structure of the EventLogObject as there is a divergence in the way and manner to access log events, primarily as a DLL node.

2.  These may also affect a bit of how you'll plug in the various features you all are currently working on.

3. You may require to 'npm install' to install a diff module dependency used is ApolloClient itself (if we decide to stick to that for purposes of parity). But then, I have created a small diff algorithm to do the same, please feel free to comment on which to move on with.

# FEATURE:
ApolloEventLog Object module implementing a Tree-like structure. Each apollo client event is a node in a derived data structure from Object map and double linked list.

# DESCRIPTION:
Further to [](https://github.com/oslabs-beta/apollo11/pull/60) which detects Local GraphQL operation detection and dispatches the entire QueryStore and MutationStore from the createURICacheEventListener through react store hooks.

This PR contains a derived data structure used to implement apolloEventLog objects from a double-linked list and an object map. All apolloEvents are now captured as a Node in the derived tree so as to move backward and forward from any given node especially when we consider a timeline that can be scrubbed.

While in the previous version we have been using 'any' types for our apolloEvent logs, we have now enforced types in the structure of the logs and cache. The types are abstracted into a module.

The types have further been integrated into the eventlog, eventdetails, cache & cachedetails component to complete the abstraction.

In addition, because the entire store is dispatched into the apolloEvent log object when the apolloclient object callback is invoked, the apolloEvent object uses a shallow diff algorithm of object key/value pairs to determine the lastest event before pushing into the DLL tree. The object map acts as a temporary store to keep intermediary changes arriving from the query and mutation stores respectively.

# How to test
Plugin in. to the full-stack apollo client tutorial, open the dev tool. Features have not changed, but our approach to intercepting local events, the cache.

